### PR TITLE
Change stream naming scheme and add report ID field

### DIFF
--- a/tap_doubleclick_campaign_manager/discover.py
+++ b/tap_doubleclick_campaign_manager/discover.py
@@ -13,15 +13,6 @@ def sanitize_name(report_name):
     report_name = re.sub(r'[\s\-\/]', '_', report_name.lower())
     return re.sub(r'[^a-z0-9_]', '', report_name)
 
-def handle_duplicate(report_configs, stream_name, number=1):
-    new_stream_name = stream_name + '_' + str(number)
-    if number == 1 and stream_name in report_configs:
-        report_configs[new_stream_name] = report_configs[stream_name]
-        del report_configs[stream_name]
-    elif new_stream_name not in report_configs:
-        return new_stream_name
-    return handle_duplicate(report_configs, stream_name, number=number + 1)
-
 def discover_streams(service, config):
     profile_id = config.get('profile_id')
 
@@ -37,8 +28,6 @@ def discover_streams(service, config):
     report_configs = {}
     for report in reports:
         stream_name = sanitize_name(report['name'])
-        if stream_name in report_configs:
-            stream_name = handle_duplicate(report_configs, stream_name)
         report_configs[stream_name] = report
 
     field_type_lookup = get_field_type_lookup()
@@ -67,7 +56,8 @@ def discover_streams(service, config):
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
-            tap_stream_id=stream_name,
+            stream_alias=stream_name,
+            tap_stream_id='{}_{}'.format(stream_name, report['id']),
             key_properties=[],
             schema=schema,
             metadata=metadata

--- a/tap_doubleclick_campaign_manager/schema.py
+++ b/tap_doubleclick_campaign_manager/schema.py
@@ -2,6 +2,7 @@ import os
 import json
 
 SINGER_REPORT_FIELD = '_sdc_report_time'
+REPORT_ID_FIELD = '_sdc_report_id'
 
 def get_field_type_lookup():
     path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -50,6 +51,10 @@ def get_schema(stream_name, fieldmap):
     properties[SINGER_REPORT_FIELD] = {
         'type': 'string',
         'format': 'date-time'
+    }
+
+    properties[REPORT_ID_FIELD] = {
+        'type': 'integer'
     }
 
     for field in fieldmap:

--- a/tap_doubleclick_campaign_manager/sync_reports.py
+++ b/tap_doubleclick_campaign_manager/sync_reports.py
@@ -10,6 +10,7 @@ from googleapiclient import http
 
 from tap_doubleclick_campaign_manager.schema import (
     SINGER_REPORT_FIELD,
+    REPORT_ID_FIELD,
     get_fields,
     get_schema,
     get_field_type_lookup
@@ -76,6 +77,7 @@ def transform_field(dfa_type, value):
 def process_file(service, fieldmap, report_config, file_id, report_time):
     report_id = report_config['report_id']
     stream_name = report_config['stream_name']
+    stream_alias = report_config['stream_alias']
 
     request = service.files().get_media(reportId=report_id, fileId=file_id)
 
@@ -106,8 +108,9 @@ def process_file(service, fieldmap, report_config, file_id, report_time):
                 obj[field['name']] = transform_field(field['type'], row[i])
 
             obj[SINGER_REPORT_FIELD] = report_time
+            obj[REPORT_ID_FIELD] = report_id
 
-            singer.write_record(stream_name, obj)
+            singer.write_record(stream_name, obj, stream_alias=stream_alias)
             line_state['count'] += 1
     
     stream = StreamFunc(test_transform)
@@ -203,7 +206,8 @@ def sync_reports(service, config, catalog, state):
         if root_metadata.get('selected') is True:
             reports.append({
                 'report_id': root_metadata['tap-doubleclick-campaign-manager.report-id'],
-                'stream_name': stream.tap_stream_id
+                'stream_name': stream.tap_stream_id,
+                'stream_alias': stream.stream_alias
             })
     reports = sorted(reports, key=lambda x: x['report_id'])
 

--- a/tap_doubleclick_campaign_manager/sync_reports.py
+++ b/tap_doubleclick_campaign_manager/sync_reports.py
@@ -127,6 +127,7 @@ def process_file(service, fieldmap, report_config, file_id, report_time):
 def sync_report(service, field_type_lookup, profile_id, report_config):
     report_id = report_config['report_id']
     stream_name = report_config['stream_name']
+    stream_alias = report_config['stream_alias']
 
     LOGGER.info("%s: Starting sync", stream_name)
 
@@ -140,7 +141,7 @@ def sync_report(service, field_type_lookup, profile_id, report_config):
 
     fieldmap = get_fields(field_type_lookup, report)
     schema = get_schema(stream_name, fieldmap)
-    singer.write_schema(stream_name, schema, [])
+    singer.write_schema(stream_name, schema, [], stream_alias=stream_alias)
 
     with singer.metrics.job_timer('run_report'):
         report_time = datetime.utcnow().isoformat() + 'Z'


### PR DESCRIPTION
### Overview
 - Changes stream naming scheme
     - catalog_entry.stream will be the sanitized report name
     - catalog_entry.stream_alias will also be the sanitized report name
     - catalog_entry.tap_stream_id will be sanitized report name + _ + report id
 - catalog_entry.stream_alias is included in each write_record
 - _sdc_report_id is added to each report with the report id

### Functional Tests
- Running a discover and selecting the streams in the output
- Running a sync against the new catalog