### PR TITLE
upgrade to v3.4

### DIFF
--- a/tap_doubleclick_campaign_manager/__init__.py
+++ b/tap_doubleclick_campaign_manager/__init__.py
@@ -36,7 +36,7 @@ def get_service(config):
     user_agent = config.get('user_agent')
     if user_agent:
         http = set_user_agent(http, user_agent)
-    return discovery.build('dfareporting', 'v3.3', http=http, cache_discovery=False)
+    return discovery.build('dfareporting', 'v3.4', http=http, cache_discovery=False)
 
 def do_discover(service, config):
     LOGGER.info("Starting discover")


### PR DESCRIPTION
# Description of change

I got notified about API v3.3 by Campaign Manager 360 API Team:

> In accordance with our deprecation schedule, we will be sunsetting version 3.3 of the API on June 30, 2021. Requests to version 3.3 will no longer work after this date, preventing you from updating and accessing information in Campaign Manager 360. To avoid an interruption in service, you must migrate to a newer API version as soon as possible.

> To learn about changes between versions and get tips for migrating, visit the API developer site. Also consider subscribing to the Google Ads Developer Blog to stay up to date about new releases, upcoming sunsets, and changes to the API.

> If you have technical questions regarding new versions of the API, please reach out via the developer forum.


# Manual QA steps
 - 
 
# Risks
 
[Version 3.4](https://developers.google.com/doubleclick-advertisers/rel_notes) does not seem to remove any resources available in the past, which makes the upgrade safe and backwards compatible.
 
# Rollback steps
 - revert this branch
