### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
-            pip install -U pip setuptools
-            pip install .[dev]
+            uv pip install -U pip setuptools
+            uv pip install .[dev]
       - run:
           when: always
           name: 'Unit Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -m venv /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
             pip install -U pip setuptools
             pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies