### PR TITLE
PR 3 - [SAC-28826] - Tests for `forced-replication-method` addition in catalog

### DIFF
--- a/tap_doubleclick_campaign_manager/discover.py
+++ b/tap_doubleclick_campaign_manager/discover.py
@@ -42,13 +42,11 @@ def discover_streams(service, config):
 
         metadata = []
         metadata.append({
-            'metadata': {
-                'tap-doubleclick-campaign-manager.report-id': report['id']
-            },
             'breadcrumb': [],
             'metadata': {
+                'tap-doubleclick-campaign-manager.report-id': report['id'],
                 'forced-replication-method': 'FULL_TABLE'
-            },
+            }
         })
 
         for prop in schema_dict['properties'].keys():

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,225 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_doubleclick_campaign_manager.discover import discover_streams, sanitize_name
+
+
+class TestDiscoverFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_sanitize_name(self):
+        """Test that sanitize_name correctly formats report names"""
+        # Test spaces and dashes are replaced with underscores
+        actual = sanitize_name("Test Report Name")
+        expected = "test_report_name"
+        self.assertEqual(expected, actual)
+
+        # Test special characters are removed
+        actual = sanitize_name("Test-Report/Name!")
+        expected = "test_report_name"
+        self.assertEqual(expected, actual)
+
+        # Test mixed case and symbols
+        actual = sanitize_name("Complex_Report-Name 2023!")
+        expected = "complex_report_name_2023"
+        self.assertEqual(expected, actual)
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_includes_forced_replication_method(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that discover_streams includes forced-replication-method in metadata"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock report data
+        mock_reports = [
+            {
+                'id': 123,
+                'name': 'Test Report',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['date'],
+                    'metricNames': ['impressions']
+                }
+            }
+        ]
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {
+            'date': 'string',
+            'impressions': 'long'
+        }
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        # Verify the result structure
+        self.assertIsInstance(result, dict)
+        self.assertIn('streams', result)
+        self.assertEqual(len(result['streams']), 1)
+        
+        stream = result['streams'][0]
+        
+        # Check basic stream properties
+        self.assertEqual(stream['stream'], 'test_report')
+        self.assertEqual(stream['tap_stream_id'], 'test_report_123')
+        
+        # Check metadata structure
+        self.assertIn('metadata', stream)
+        metadata = stream['metadata']
+        
+        # Find the root metadata entry (breadcrumb: [])
+        root_metadata = None
+        for meta in metadata:
+            if meta['breadcrumb'] == []:
+                root_metadata = meta
+                break
+        
+        self.assertIsNotNone(root_metadata, "Root metadata entry not found")
+        
+        # Check that forced-replication-method is present in root metadata
+        self.assertIn('metadata', root_metadata)
+        self.assertIn('forced-replication-method', root_metadata['metadata'])
+        self.assertEqual(root_metadata['metadata']['forced-replication-method'], 'FULL_TABLE')
+        
+        # Check that report-id is also present (existing functionality)
+        self.assertIn('tap-doubleclick-campaign-manager.report-id', root_metadata['metadata'])
+        self.assertEqual(root_metadata['metadata']['tap-doubleclick-campaign-manager.report-id'], 123)
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_handles_multiple_reports(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that discover_streams correctly handles multiple reports with forced-replication-method"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock multiple report data
+        mock_reports = [
+            {
+                'id': 123,
+                'name': 'First Report',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['date'],
+                    'metricNames': ['impressions']
+                }
+            },
+            {
+                'id': 456,
+                'name': 'Second Report',
+                'type': 'FLOODLIGHT',
+                'floodlightCriteria': {
+                    'dimensions': ['conversionId'],
+                    'metricNames': ['totalConversions']
+                }
+            }
+        ]
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {
+            'date': 'string',
+            'impressions': 'long',
+            'conversionId': 'long',
+            'totalConversions': 'long'
+        }
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        # Verify we have 2 streams
+        self.assertEqual(len(result['streams']), 2)
+        
+        # Check both streams have forced-replication-method
+        for stream in result['streams']:
+            metadata = stream['metadata']
+            root_metadata = None
+            for meta in metadata:
+                if meta['breadcrumb'] == []:
+                    root_metadata = meta
+                    break
+            
+            self.assertIsNotNone(root_metadata)
+            self.assertIn('forced-replication-method', root_metadata['metadata'])
+            self.assertEqual(root_metadata['metadata']['forced-replication-method'], 'FULL_TABLE')
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_metadata_structure(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that discover_streams creates correct metadata structure for all fields"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock report data
+        mock_reports = [
+            {
+                'id': 789,
+                'name': 'Metadata Test Report',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['date', 'campaignId'],
+                    'metricNames': ['impressions', 'clicks']
+                }
+            }
+        ]
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {
+            'date': 'string',
+            'campaignId': 'long',
+            'impressions': 'long',
+            'clicks': 'long'
+        }
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        stream = result['streams'][0]
+        metadata = stream['metadata']
+        
+        # Should have metadata for: root + 6 fields (date, campaignId, impressions, clicks, _sdc_report_time, _sdc_report_id)
+        expected_metadata_count = 7  # 1 root + 6 field metadata entries
+        self.assertEqual(len(metadata), expected_metadata_count)
+        
+        # Check that all field metadata entries have inclusion: automatic
+        field_metadata_entries = [meta for meta in metadata if len(meta['breadcrumb']) == 2]
+        for meta in field_metadata_entries:
+            self.assertEqual(meta['metadata']['inclusion'], 'automatic')
+            self.assertEqual(meta['breadcrumb'][0], 'properties')

--- a/tests/unittests/test_discover_edge_cases.py
+++ b/tests/unittests/test_discover_edge_cases.py
@@ -1,0 +1,230 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_doubleclick_campaign_manager.discover import discover_streams
+
+
+class TestDiscoverEdgeCases(unittest.TestCase):
+    """Test edge cases for the forced-replication-method functionality"""
+
+    def setUp(self):
+        self.maxDiff = None
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_different_report_types(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that forced-replication-method is included for all report types"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock reports of different types
+        mock_reports = [
+            {
+                'id': 1,
+                'name': 'Standard Report',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['date'],
+                    'metricNames': ['impressions']
+                }
+            },
+            {
+                'id': 2,
+                'name': 'Floodlight Report',
+                'type': 'FLOODLIGHT',
+                'floodlightCriteria': {
+                    'dimensions': ['conversionId'],
+                    'metricNames': ['totalConversions']
+                }
+            },
+            {
+                'id': 3,
+                'name': 'Cross Dimension Report',
+                'type': 'CROSS_DIMENSION_REACH',
+                'crossDimensionReachCriteria': {
+                    'breakdown': ['age'],
+                    'metricNames': ['reach'],
+                    'overlapMetricNames': ['overlapReach']
+                }
+            },
+            {
+                'id': 4,
+                'name': 'Path to Conversion Report',
+                'type': 'PATH_TO_CONVERSION',
+                'pathToConversionCriteria': {
+                    'conversionDimensions': ['conversionId'],
+                    'perInteractionDimensions': ['date'],
+                    'customFloodlightVariables': ['u1'],
+                    'metricNames': ['totalConversions']
+                }
+            },
+            {
+                'id': 5,
+                'name': 'Reach Report',
+                'type': 'REACH',
+                'reachCriteria': {
+                    'dimensions': ['date'],
+                    'metricNames': ['impressions'],
+                    'reachByFrequencyMetricNames': ['reach1Plus']
+                }
+            }
+        ]
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {
+            'date': 'string',
+            'impressions': 'long',
+            'conversionId': 'long',
+            'totalConversions': 'long',
+            'age': 'string',
+            'reach': 'long',
+            'overlapReach': 'long',
+            'u1': 'string',
+            'reach1Plus': 'long'
+        }
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        # Verify we have 5 streams
+        self.assertEqual(len(result['streams']), 5)
+        
+        # Check that all streams have forced-replication-method in metadata
+        for i, stream in enumerate(result['streams']):
+            with self.subTest(report_type=mock_reports[i]['type'], stream_name=stream['stream']):
+                metadata = stream['metadata']
+                
+                # Find the root metadata entry
+                root_metadata = None
+                for meta in metadata:
+                    if meta['breadcrumb'] == []:
+                        root_metadata = meta
+                        break
+                
+                self.assertIsNotNone(root_metadata, f"Root metadata not found for {stream['stream']}")
+                
+                # Check forced-replication-method is present
+                self.assertIn('forced-replication-method', root_metadata['metadata'])
+                self.assertEqual(root_metadata['metadata']['forced-replication-method'], 'FULL_TABLE')
+                
+                # Check report-id is also present
+                self.assertIn('tap-doubleclick-campaign-manager.report-id', root_metadata['metadata'])
+                self.assertEqual(root_metadata['metadata']['tap-doubleclick-campaign-manager.report-id'], mock_reports[i]['id'])
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_empty_reports_list(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that discover_streams handles empty reports list gracefully"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock empty reports list
+        mock_reports = []
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {}
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        # Verify we have no streams
+        self.assertIsInstance(result, dict)
+        self.assertIn('streams', result)
+        self.assertEqual(len(result['streams']), 0)
+
+    @patch('tap_doubleclick_campaign_manager.discover.DoubleclickCampaignManagerClient')
+    @patch('tap_doubleclick_campaign_manager.discover.get_field_type_lookup')
+    def test_discover_streams_with_special_characters_in_names(self, mock_get_field_type_lookup, mock_client_class):
+        """Test that discover_streams handles report names with special characters"""
+        
+        # Mock the service and client
+        mock_service = MagicMock()
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        # Mock reports with special character names
+        mock_reports = [
+            {
+                'id': 100,
+                'name': 'Report with Spaces & Special-Characters!',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['date'],
+                    'metricNames': ['impressions']
+                }
+            },
+            {
+                'id': 101,
+                'name': 'Report/With\\Slashes',
+                'type': 'STANDARD',
+                'criteria': {
+                    'dimensions': ['campaignId'],
+                    'metricNames': ['clicks']
+                }
+            }
+        ]
+        
+        # Configure mock responses
+        mock_reports_list = MagicMock()
+        mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
+        mock_service.reports.return_value = mock_reports_list
+        mock_client.make_request.return_value = mock_reports
+        
+        # Mock field type lookup
+        mock_get_field_type_lookup.return_value = {
+            'date': 'string',
+            'impressions': 'long',
+            'campaignId': 'long',
+            'clicks': 'long'
+        }
+        
+        # Test config
+        config = {'profile_id': '12345'}
+        
+        # Call discover_streams
+        result = discover_streams(mock_service, config)
+        
+        # Verify we have 2 streams
+        self.assertEqual(len(result['streams']), 2)
+        
+        # Check stream names are properly sanitized
+        stream_names = [stream['stream'] for stream in result['streams']]
+        self.assertIn('report_with_spaces__special_characters', stream_names)
+        self.assertIn('report_withslashes', stream_names)
+        
+        # Check that both streams have forced-replication-method
+        for stream in result['streams']:
+            metadata = stream['metadata']
+            root_metadata = None
+            for meta in metadata:
+                if meta['breadcrumb'] == []:
+                    root_metadata = meta
+                    break
+            
+            self.assertIsNotNone(root_metadata)
+            self.assertIn('forced-replication-method', root_metadata['metadata'])
+            self.assertEqual(root_metadata['metadata']['forced-replication-method'], 'FULL_TABLE')

--- a/tests/unittests/test_schema_integration.py
+++ b/tests/unittests/test_schema_integration.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_doubleclick_campaign_manager.schema import get_schema, SINGER_REPORT_FIELD, REPORT_ID_FIELD
+
+
+class TestSchemaIntegration(unittest.TestCase):
+    """Integration tests for schema functionality related to metadata changes"""
+
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_get_schema_includes_required_singer_fields(self):
+        """Test that get_schema includes the required Singer fields regardless of report type"""
+        
+        fieldmap = [
+            {'name': 'customField', 'type': 'string'}
+        ]
+        
+        actual = get_schema('test_stream', fieldmap)
+        
+        # Verify Singer required fields are always present
+        self.assertIn(SINGER_REPORT_FIELD, actual['properties'])
+        self.assertIn(REPORT_ID_FIELD, actual['properties'])
+        
+        # Verify their types are correct
+        self.assertEqual(actual['properties'][SINGER_REPORT_FIELD]['type'], 'string')
+        self.assertEqual(actual['properties'][SINGER_REPORT_FIELD]['format'], 'date-time')
+        self.assertEqual(actual['properties'][REPORT_ID_FIELD]['type'], 'integer')
+        
+        # Verify custom field is also present
+        self.assertIn('customField', actual['properties'])
+        self.assertEqual(actual['properties']['customField']['type'], ['null', 'string'])
+
+    def test_get_schema_with_complex_fieldmap(self):
+        """Test schema generation with complex field types to ensure compatibility with metadata changes"""
+        
+        fieldmap = [
+            {'name': 'stringField', 'type': 'string'},
+            {'name': 'longField', 'type': 'long'},
+            {'name': 'doubleField', 'type': 'double'},
+            {'name': 'multiTypeField', 'type': ['long', 'string']}
+        ]
+        
+        actual = get_schema('complex_stream', fieldmap)
+        
+        # Verify all field types are correctly converted
+        expected_properties = {
+            'stringField': {'type': ['null', 'string']},
+            'longField': {'type': ['null', 'integer']},
+            'doubleField': {'type': ['null', 'number']},
+            'multiTypeField': {'type': ['null', 'integer', 'string']},
+            SINGER_REPORT_FIELD: {'type': 'string', 'format': 'date-time'},
+            REPORT_ID_FIELD: {'type': 'integer'}
+        }
+        
+        for field_name, expected_field in expected_properties.items():
+            self.assertIn(field_name, actual['properties'])
+            self.assertEqual(actual['properties'][field_name], expected_field)
+
+    def test_schema_structure_compatibility(self):
+        """Test that schema structure remains compatible with catalog metadata"""
+        
+        fieldmap = [{'name': 'testField', 'type': 'string'}]
+        schema = get_schema('test_stream', fieldmap)
+        
+        # Verify schema has required top-level structure
+        self.assertIn('type', schema)
+        self.assertEqual(schema['type'], 'object')
+        self.assertIn('properties', schema)
+        self.assertIn('addtionalProperties', schema)  # Note: This appears to be a typo in the original code
+        self.assertEqual(schema['addtionalProperties'], False)
+        
+        # Verify properties is a dict
+        self.assertIsInstance(schema['properties'], dict)


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-28826

Tests for new `forced-replication-method` parameter to the connector’s catalog. 

# Rollback steps
 - revert this branch


