### PR TITLE
Upgrades Google API dependencies to address Twistlock security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.1
+  * Upgrade package versions to fix CVE issues
+    * google-api-python-client==2.193.0 -> 2.196.0
+    * google-auth==2.49.1 -> 2.53.0
+
 ## 1.5.0
   * Python version upgrade to 3.12
   * forced-replication-method addition

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-doubleclick-campaign-manager",
-    version="1.5.0",
+    version="1.5.1",
     description="Singer.io tap for extracting data from the DoubleClick for Campaign Managers API",
     author="Stitch",
     url="http://singer.io",
@@ -12,8 +12,8 @@ setup(
     py_modules=["tap_doubleclick_campaign_manager"],
     install_requires=[
         "singer-python==6.8.0",
-        "google-api-python-client==2.193.0",
-        "google-auth==2.49.1",
+        "google-api-python-client==2.196.0",
+        "google-auth==2.53.0",
         "backoff==2.2.1",
     ],
     extras_require={


### PR DESCRIPTION
# Description of change
- Bump google-api-python-client from 2.193.0 to 2.196.0
- Bump google-auth from 2.49.1 to 2.53.0
- Fixes CVE-2026-44432 (urllib3 vulnerability)
- Fixes CVE-2026-0994 (protobuf DoS vulnerability)
- Version bumped to 1.5.1
- All unit tests passing (114 tests)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
