### PR TITLE
[SAC-30604] - Mock Integration Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,17 +28,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
             coverage run -m pytest tests/ --ignore=tests/unittests
             coverage report
-      - run:
-          name: 'Integration Tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            uv pip install --upgrade awscli
-            uv pip install .
-            uv pip install pytest
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
-            unset USE_STITCH_BACKEND
-            run-test --tap=tap-doubleclick-campaign-manager tests
       - slack/notify-on-failure:
           only_for_branches: master
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ jobs:
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
             uv pip install pytest coverage
             coverage run -m pytest tests/unittests
+            coverage report
+      - run:
+          name: 'Mock Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
+            coverage run -m pytest tests/ --ignore=tests/unittests
+            coverage report
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-doubleclick-campaign-manager/bin/activate
             uv pip install pytest coverage
             coverage run -m pytest tests/unittests
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
+            uv pip install .
+            uv pip install pytest
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            unset USE_STITCH_BACKEND
+            run-test --tap=tap-doubleclick-campaign-manager tests
       - slack/notify-on-failure:
           only_for_branches: master
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.2
+  * Fix silent data truncation in `discover_streams()` — `reports.list` is a paginated API (max 10 results per page) and the previous implementation only fetched the first page, causing reports beyond page 1 to be silently omitted from the catalog. Added `nextPageToken` loop to collect all pages. [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
+  * Add mock integration tests for all five DCM report type streams (STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH) [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
+
 ## 1.5.1
   * Upgrade package versions to fix CVE issues
     * google-api-python-client==2.193.0 -> 2.196.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## 1.5.2
-  * Fix silent data truncation in `discover_streams()` — `reports.list` is a paginated API (max 10 results per page) and the previous implementation only fetched the first page, causing reports beyond page 1 to be silently omitted from the catalog. Added `nextPageToken` loop to collect all pages. [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
-  * Add mock integration tests for all five DCM report type streams (STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH) [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
+  * Fix `discover_streams()` to paginate through all pages of `reports.list` (previously only first page was fetched) [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
+  * Add mock integration tests for all five DCM report types [#43](https://github.com/singer-io/tap-doubleclick-campaign-manager/pull/43)
 
 ## 1.5.1
   * Upgrade package versions to fix CVE issues

--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ To run `tap-doubleclick-campaign-manager` with the configuration file, use this 
 › tap-doubleclick-campaign-manager -c my-config.json
 ```
 
+## Testing
+
+Install the development dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+### Unit Tests
+
+```bash
+pytest tests/unittests
+```
+
+### Mock Integration Tests
+
+```bash
+pytest tests/ --ignore=tests/unittests
+```
+
+To run with coverage:
+
+```bash
+coverage run -m pytest tests/ --ignore=tests/unittests
+coverage report
+```
+
 ---
 
 Copyright &copy; 2018 Stitch

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-doubleclick-campaign-manager",
-    version="1.5.1",
+    version="1.5.2",
     description="Singer.io tap for extracting data from the DoubleClick for Campaign Managers API",
     author="Stitch",
     url="http://singer.io",

--- a/tap_doubleclick_campaign_manager/discover.py
+++ b/tap_doubleclick_campaign_manager/discover.py
@@ -19,7 +19,12 @@ def discover_streams(service, config):
 
     all_reports = []
     page_token = None
-    while True:
+    has_more_pages = True
+    pages_fetched = 0
+    max_pages = 1000
+    seen_page_tokens = set()
+
+    while has_more_pages and pages_fetched < max_pages:
         params = {'profileId': profile_id}
         if page_token:
             params['pageToken'] = page_token
@@ -29,10 +34,17 @@ def discover_streams(service, config):
                 .list(**params)
                 .execute()
         )
+        pages_fetched += 1
         all_reports.extend(response.get('items') or [])
-        page_token = response.get('nextPageToken')
-        if not page_token:
-            break
+        next_page_token = response.get('nextPageToken')
+        if not next_page_token:
+            has_more_pages = False
+        elif next_page_token in seen_page_tokens:
+            # Defensive guard against a looping API token.
+            has_more_pages = False
+        else:
+            seen_page_tokens.add(next_page_token)
+            page_token = next_page_token
 
     reports = sorted(all_reports, key=lambda x: x['id'])
     report_configs = {}

--- a/tap_doubleclick_campaign_manager/discover.py
+++ b/tap_doubleclick_campaign_manager/discover.py
@@ -17,15 +17,24 @@ def sanitize_name(report_name):
 def discover_streams(service, config):
     profile_id = config.get('profile_id')
 
-    reports = DoubleclickCampaignManagerClient().make_request(
-        lambda: service
-            .reports()
-            .list(profileId=profile_id)
-            .execute()
-            .get('items')
-    )
+    all_reports = []
+    page_token = None
+    while True:
+        params = {'profileId': profile_id}
+        if page_token:
+            params['pageToken'] = page_token
+        response = DoubleclickCampaignManagerClient().make_request(
+            lambda: service
+                .reports()
+                .list(**params)
+                .execute()
+        )
+        all_reports.extend(response.get('items') or [])
+        page_token = response.get('nextPageToken')
+        if not page_token:
+            break
 
-    reports = sorted(reports, key=lambda x: x['id'])
+    reports = sorted(all_reports, key=lambda x: x['id'])
     report_configs = {}
     for report in reports:
         stream_name = sanitize_name(report['name'])

--- a/tests/base.py
+++ b/tests/base.py
@@ -132,7 +132,7 @@ def build_sample_rows_for_report(report: dict, n: int = 2) -> list[list]:
     """
     Build *n* sample data rows whose values match the report's field types.
 
-    Integers → 100, 200, …; strings → "2024-01-01", "2024-01-02", …
+    Integers → 100, 200, …; date-like strings → RFC3339 UTC values.
     """
     field_type_lookup = get_field_type_lookup()
     fieldmap = get_fields(field_type_lookup, report)
@@ -150,8 +150,17 @@ def build_sample_rows_for_report(report: dict, n: int = 2) -> list[list]:
             elif ft == "boolean":
                 row.append("true" if i % 2 == 0 else "false")
             else:
-                # string / date fields: use a realistic date string
-                row.append(f"2024-01-0{i + 1}")
+                # Use RFC3339 for date-like columns to match checklist expectations.
+                field_name = field["name"]
+                if (
+                    field_name.endswith("_time")
+                    or field_name.endswith("_date")
+                    or "date" in field_name
+                    or "time" in field_name
+                ):
+                    row.append(f"2024-01-{i + 1:02d}T00:00:00Z")
+                else:
+                    row.append(f"value_{i + 1}")
         rows.append(row)
     return rows
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,394 @@
+"""Base test mixin for tap-doubleclick-campaign-manager mock integration tests.
+
+Not a TestCase itself — mix with unittest.TestCase in each test file.
+All Google API calls are patched at the service level; no live credentials required.
+
+Mock report fixtures cover all five DCM report types:
+  STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+
+from singer.catalog import Catalog
+
+from tap_doubleclick_campaign_manager.discover import discover_streams, sanitize_name
+from tap_doubleclick_campaign_manager.schema import (
+    SINGER_REPORT_FIELD,
+    REPORT_ID_FIELD,
+    get_field_type_lookup,
+    get_fields,
+    get_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Static mock report definitions (one per supported DCM report type)
+# Payloads mirror the structure returned by reports.get / reports.list.
+# ---------------------------------------------------------------------------
+
+STANDARD_REPORT = {
+    "id": 1001,
+    "name": "Standard Report",
+    "type": "STANDARD",
+    "criteria": {
+        "dimensions": [{"name": "date"}, {"name": "campaign"}],
+        "metricNames": ["impressions", "clicks"],
+    },
+}
+
+FLOODLIGHT_REPORT = {
+    "id": 1002,
+    "name": "Floodlight Report",
+    "type": "FLOODLIGHT",
+    "floodlightCriteria": {
+        "dimensions": [{"name": "date"}, {"name": "activity"}],
+        "metricNames": ["totalConversions"],
+    },
+}
+
+CROSS_DIMENSION_REACH_REPORT = {
+    "id": 1003,
+    "name": "Cross Dimension Reach Report",
+    "type": "CROSS_DIMENSION_REACH",
+    "crossDimensionReachCriteria": {
+        "breakdown": [{"name": "date"}],
+        "metricNames": ["uniqueReachTotalReach"],
+        "overlapMetricNames": ["uniqueReachIncrementalReach"],
+    },
+}
+
+PATH_TO_CONVERSION_REPORT = {
+    "id": 1004,
+    "name": "Path To Conversion Report",
+    "type": "PATH_TO_CONVERSION",
+    "pathToConversionCriteria": {
+        "conversionDimensions": [{"name": "date"}],
+        "perInteractionDimensions": [{"name": "campaign"}],
+        "customFloodlightVariables": [],
+        "metricNames": ["totalConversions"],
+    },
+}
+
+REACH_REPORT = {
+    "id": 1005,
+    "name": "Reach Report",
+    "type": "REACH",
+    "reachCriteria": {
+        "dimensions": [{"name": "date"}],
+        "metricNames": ["uniqueReachTotalReach"],
+        "reachByFrequencyMetricNames": ["reachByFrequency"],
+    },
+}
+
+ALL_MOCK_REPORTS = [
+    STANDARD_REPORT,
+    FLOODLIGHT_REPORT,
+    CROSS_DIMENSION_REACH_REPORT,
+    PATH_TO_CONVERSION_REPORT,
+    REACH_REPORT,
+]
+
+# Mapping from a report dict to its expected tap_stream_id
+def _expected_tap_stream_id(report):
+    stream_name = sanitize_name(report["name"])
+    return f"{stream_name}_{report['id']}"
+
+EXPECTED_TAP_STREAM_IDS = {_expected_tap_stream_id(r) for r in ALL_MOCK_REPORTS}
+
+# Expected stream-name → report mapping (tap_stream_id → report)
+REPORT_BY_TAP_STREAM_ID = {_expected_tap_stream_id(r): r for r in ALL_MOCK_REPORTS}
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+def build_dcm_csv(headers: list[str], rows: list[list]) -> bytes:
+    """Return mock DCM CSV bytes in the format expected by process_file().
+
+    Format:
+        Report Fields
+        col1,col2,...
+        val1,val2,...
+        Grand Total:,...
+    """
+    lines = ["Report Fields", ",".join(headers)]
+    for row in rows:
+        lines.append(",".join(str(v) for v in row))
+    lines.append("Grand Total:" + "," * (len(headers) - 1))
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def get_report_headers(report: dict) -> list[str]:
+    """Return the ordered list of column names for a report (dimensions + metrics)."""
+    field_type_lookup = get_field_type_lookup()
+    fieldmap = get_fields(field_type_lookup, report)
+    return [f["name"] for f in fieldmap]
+
+
+def build_sample_rows_for_report(report: dict, n: int = 2) -> list[list]:
+    """
+    Build *n* sample data rows whose values match the report's field types.
+
+    Integers → 100, 200, …; strings → "2024-01-01", "2024-01-02", …
+    """
+    field_type_lookup = get_field_type_lookup()
+    fieldmap = get_fields(field_type_lookup, report)
+    rows = []
+    for i in range(n):
+        row = []
+        for field in fieldmap:
+            ft = field["type"]
+            if isinstance(ft, list):
+                ft = [t for t in ft if t != "null"][0] if ft else "string"
+            if ft in ("long", "integer"):
+                row.append(str((i + 1) * 100))
+            elif ft in ("double", "number"):
+                row.append(f"{(i + 1) * 1.5:.1f}")
+            elif ft == "boolean":
+                row.append("true" if i % 2 == 0 else "false")
+            else:
+                # string / date fields: use a realistic date string
+                row.append(f"2024-01-0{i + 1}")
+        rows.append(row)
+    return rows
+
+
+def make_mock_downloader_class(csv_bytes: bytes):
+    """
+    Return a mock MediaIoBaseDownload class that writes *csv_bytes* to the
+    stream fd when next_chunk() is first called.
+
+    Usage::
+
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)):
+            ...
+    """
+    class _MockDownloader:
+        def __init__(self, fd, request, chunksize=None):
+            self._fd = fd
+            self._done = False
+
+        def next_chunk(self):
+            if not self._done:
+                self._fd.write(csv_bytes)
+                self._done = True
+            return (MagicMock(), True)
+
+    return _MockDownloader
+
+
+# ---------------------------------------------------------------------------
+# Mock Google API service builder
+# ---------------------------------------------------------------------------
+
+def build_mock_service(
+    reports_pages: list[list[dict]] | None = None,
+    report_details: dict | None = None,
+    file_status: str = "REPORT_AVAILABLE",
+    file_id: str = "mock_file_id_1",
+) -> MagicMock:
+    """
+    Build a MagicMock Google API service with pre-configured responses.
+
+    Parameters
+    ----------
+    reports_pages:
+        List of pages; each page is a list of report dicts.  For single-page
+        results pass ``[[r1, r2, ...]]``.  Subsequent pages automatically
+        receive a ``nextPageToken`` in the mocked response so that
+        ``discover_streams`` keeps fetching.
+    report_details:
+        What ``service.reports().get().execute()`` returns.  Defaults to the
+        first report in *reports_pages*.
+    file_status:
+        Status returned by ``service.files().get().execute()``.
+    file_id:
+        File id returned by ``service.reports().run().execute()``.
+    """
+    service = MagicMock()
+
+    # ── reports().list() (multi-page aware) ─────────────────────────────
+    if reports_pages is not None:
+        execute_responses = []
+        for idx, page in enumerate(reports_pages):
+            resp = {"items": page}
+            if idx < len(reports_pages) - 1:
+                resp["nextPageToken"] = f"page_token_{idx}"
+            execute_responses.append(resp)
+        service.reports.return_value.list.return_value.execute.side_effect = (
+            execute_responses
+        )
+
+    # ── reports().get() ──────────────────────────────────────────────────
+    if report_details is not None:
+        service.reports.return_value.get.return_value.execute.return_value = (
+            report_details
+        )
+
+    # ── reports().run() ──────────────────────────────────────────────────
+    service.reports.return_value.run.return_value.execute.return_value = {
+        "id": file_id
+    }
+
+    # ── files().get() (status polling) ───────────────────────────────────
+    service.files.return_value.get.return_value.execute.return_value = {
+        "status": file_status,
+        "id": file_id,
+    }
+
+    # ── files().get_media() ───────────────────────────────────────────────
+    # Returns a plain MagicMock; the MediaIoBaseDownload is patched in tests.
+    service.files.return_value.get_media.return_value = MagicMock()
+
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Catalog builder
+# ---------------------------------------------------------------------------
+
+def build_catalog_from_reports(reports: list[dict], selected: bool = True) -> Catalog:
+    """
+    Build a Singer Catalog from a list of mock report dicts — identical to
+    what discover_streams() would produce for those reports.
+    """
+    mock_service = build_mock_service(reports_pages=[reports])
+    mock_config = {"profile_id": "12345"}
+    catalog_dict = discover_streams(mock_service, mock_config)
+    catalog = Catalog.from_dict(catalog_dict)
+
+    if selected:
+        import singer.metadata as meta_mod
+        for entry in catalog.streams:
+            mdata_map = meta_mod.to_map(entry.metadata)
+            mdata_map[()]["selected"] = True
+            entry.metadata = meta_mod.to_list(mdata_map)
+
+    return catalog
+
+
+# ---------------------------------------------------------------------------
+# Base mixin
+# ---------------------------------------------------------------------------
+
+class DcmBaseTest:
+    """
+    Base mixin for tap-doubleclick-campaign-manager mock integration tests.
+
+    Not a TestCase itself — mix with unittest.TestCase in each test file.
+    """
+
+    FULL_TABLE = "FULL_TABLE"
+
+    MOCK_PROFILE_ID = "12345"
+    MOCK_CONFIG = {
+        "client_id": "mock-client-id",
+        "client_secret": "mock-client-secret",
+        "refresh_token": "mock-refresh-token",
+        "profile_id": MOCK_PROFILE_ID,
+    }
+
+    # All five DCM report types surfaced as mock fixtures
+    MOCK_REPORTS = ALL_MOCK_REPORTS
+    REPORT_BY_ID = {r["id"]: r for r in ALL_MOCK_REPORTS}
+
+    @classmethod
+    def expected_tap_stream_ids(cls) -> set[str]:
+        return EXPECTED_TAP_STREAM_IDS
+
+    @classmethod
+    def expected_stream_count(cls) -> int:
+        return len(cls.MOCK_REPORTS)
+
+    # ── Setup / teardown ────────────────────────────────────────────────
+
+    def setUp(self):
+        self.config = dict(self.MOCK_CONFIG)
+        self.state = {}
+
+    # ── Service + catalog helpers ────────────────────────────────────────
+
+    @classmethod
+    def _build_service(cls, reports=None, report_details=None,
+                       file_status="REPORT_AVAILABLE"):
+        """Return a mock service pre-loaded with *reports* (defaults to all 5)."""
+        reports = reports if reports is not None else cls.MOCK_REPORTS
+        return build_mock_service(
+            reports_pages=[reports],
+            report_details=report_details,
+            file_status=file_status,
+        )
+
+    @classmethod
+    def _discover(cls, reports=None):
+        """Run discover_streams() against a mocked service; return catalog dict."""
+        service = cls._build_service(reports=reports)
+        return discover_streams(service, cls.MOCK_CONFIG)
+
+    @classmethod
+    def _build_catalog(cls, reports=None, selected=True) -> Catalog:
+        return build_catalog_from_reports(
+            reports if reports is not None else cls.MOCK_REPORTS,
+            selected=selected,
+        )
+
+    # ── CSV / sync helpers ───────────────────────────────────────────────
+
+    @staticmethod
+    def _csv_for_report(report: dict, n_rows: int = 2) -> bytes:
+        headers = get_report_headers(report)
+        rows = build_sample_rows_for_report(report, n=n_rows)
+        return build_dcm_csv(headers, rows)
+
+    @staticmethod
+    def _downloader_class(csv_bytes: bytes):
+        return make_mock_downloader_class(csv_bytes)
+
+    def _run_sync_for_report(self, report: dict, n_rows: int = 2):
+        """
+        Full-stack mock sync of a single report.
+
+        Returns the list of Singer records written by singer.write_record.
+        """
+        import singer.metrics
+        from tap_doubleclick_campaign_manager.sync_reports import sync_report
+
+        csv_bytes = self._csv_for_report(report, n_rows=n_rows)
+        field_type_lookup = get_field_type_lookup()
+
+        service = build_mock_service(
+            reports_pages=[[report]],
+            report_details=report,
+            file_status="REPORT_AVAILABLE",
+        )
+
+        report_config = {
+            "report_id": report["id"],
+            "stream_name": _expected_tap_stream_id(report),
+            "stream_alias": _expected_tap_stream_id(report),
+            "metadata": {},
+        }
+
+        written = []
+
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema"), \
+             patch("singer.write_state"), \
+             patch("singer.write_record",
+                   side_effect=lambda s, r, **kw: written.append(r)), \
+             patch("singer.metrics.record_counter") as mock_counter, \
+             patch("singer.metrics.job_timer") as mock_timer:
+
+            mock_counter.return_value.__enter__ = lambda s: s
+            mock_counter.return_value.__exit__ = MagicMock(return_value=False)
+            mock_timer.return_value.__enter__ = lambda s: s
+            mock_timer.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+        return written

--- a/tests/base.py
+++ b/tests/base.py
@@ -276,13 +276,21 @@ def build_catalog_from_reports(reports: list[dict], selected: bool = True) -> Ca
 # ---------------------------------------------------------------------------
 
 class DcmBaseTest:
-    """
-    Base mixin for tap-doubleclick-campaign-manager mock integration tests.
+    """Base test mixin for tap-doubleclick-campaign-manager mock integration tests.
 
     Not a TestCase itself — mix with unittest.TestCase in each test file.
+    All Google API calls are patched at the service level; no live credentials required.
     """
 
+    # ── Metadata constants ───────────────────────────────────────────────
+    PRIMARY_KEYS = "primary_keys"
+    REPLICATION_METHOD = "replication_method"
+    REPLICATION_KEYS = "replication_keys"
+    OBEYS_START_DATE = "obeys_start_date"
+
     FULL_TABLE = "FULL_TABLE"
+
+    default_start_date = "2024-01-01T00:00:00Z"
 
     MOCK_PROFILE_ID = "12345"
     MOCK_CONFIG = {
@@ -296,6 +304,26 @@ class DcmBaseTest:
     MOCK_REPORTS = ALL_MOCK_REPORTS
     REPORT_BY_ID = {r["id"]: r for r in ALL_MOCK_REPORTS}
 
+    # ── Stream metadata ──────────────────────────────────────────────────
+
+    @classmethod
+    def expected_metadata(cls):
+        """Expected streams and metadata — all DCM report streams are FULL_TABLE."""
+        return {
+            _expected_tap_stream_id(r): {
+                cls.PRIMARY_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            }
+            for r in ALL_MOCK_REPORTS
+        }
+
+    @classmethod
+    def expected_stream_names(cls):
+        """Return the set of all expected tap_stream_ids."""
+        return set(cls.expected_metadata().keys())
+
     @classmethod
     def expected_tap_stream_ids(cls) -> set[str]:
         return EXPECTED_TAP_STREAM_IDS
@@ -304,11 +332,41 @@ class DcmBaseTest:
     def expected_stream_count(cls) -> int:
         return len(cls.MOCK_REPORTS)
 
+    @classmethod
+    def full_table_streams(cls):
+        """Return all streams that use FULL_TABLE replication (all DCM streams)."""
+        return {
+            s for s, m in cls.expected_metadata().items()
+            if m[cls.REPLICATION_METHOD] == cls.FULL_TABLE
+        }
+
     # ── Setup / teardown ────────────────────────────────────────────────
 
     def setUp(self):
-        self.config = dict(self.MOCK_CONFIG)
+        """Set up test fixtures with dummy config and empty state."""
+        self.config = self.get_mock_config()
         self.state = {}
+
+    def tearDown(self):
+        """Clean up after tests."""
+        pass
+
+    # ── Config helpers ───────────────────────────────────────────────────
+
+    @staticmethod
+    def get_mock_config():
+        """Return mock configuration with dummy values — no real credentials."""
+        return {
+            "client_id": "mock-client-id",
+            "client_secret": "mock-client-secret",
+            "refresh_token": "mock-refresh-token",
+            "profile_id": "12345",
+        }
+
+    @staticmethod
+    def get_mock_state():
+        """Return initial mock state."""
+        return {}
 
     # ── Service + catalog helpers ────────────────────────────────────────
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -256,6 +256,3 @@ class DcmAllFieldsTest(DcmBaseTest, unittest.TestCase):
                     self.assertIn(SINGER_REPORT_FIELD, rec)
                     self.assertIn(REPORT_ID_FIELD, rec)
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -4,6 +4,7 @@ Patches MediaIoBaseDownload and singer.write_record to capture written records
 and verify every dimension/metric column plus SdC system fields are present.
 No live credentials or network access required.
 """
+from datetime import datetime
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -53,6 +54,10 @@ KNOWN_MISSING_FIELDS: dict[str, set[str]] = {}
 class DcmAllFieldsTest(DcmBaseTest, unittest.TestCase):
     """Ensure every schema field appears in the records written during sync."""
 
+    @staticmethod
+    def _assert_rfc3339_datetime(value: str):
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+
     # ── Generic assertion helper ─────────────────────────────────────────
 
     def _assert_all_report_fields_present(self, report: dict, n_rows: int = 2):
@@ -73,16 +78,38 @@ class DcmAllFieldsTest(DcmBaseTest, unittest.TestCase):
         required = expected_fields - known_missing
 
         actual_fields = set().union(*(set(r.keys()) for r in written))
-        missing = required - actual_fields
-
-        self.assertEqual(
-            missing,
-            set(),
+        self.assertSetEqual(
+            actual_fields,
+            required,
             msg=(
-                f"Stream '{tap_stream_id}': fields missing from written records: "
-                f"{missing}"
+                f"Stream '{tap_stream_id}': expected exact fields {required}, "
+                f"got {actual_fields}"
             ),
         )
+
+    def _assert_datetime_fields_are_rfc3339(self, report: dict):
+        """Fields with JSON Schema format=date-time must contain RFC3339 strings."""
+        field_type_lookup = get_field_type_lookup()
+        schema = self._schema_for_report(report, field_type_lookup)
+        datetime_fields = [
+            name for name, props in schema["properties"].items()
+            if props.get("format") == "date-time"
+        ]
+        written = self._run_sync_for_report(report)
+        for rec in written:
+            for field in datetime_fields:
+                value = rec.get(field)
+                with self.subTest(report_id=report["id"], field=field):
+                    self.assertIsNotNone(value)
+                    self.assertIsInstance(value, str)
+                    self._assert_rfc3339_datetime(value)
+
+    @staticmethod
+    def _schema_for_report(report: dict, field_type_lookup: dict):
+        from tap_doubleclick_campaign_manager.schema import get_fields, get_schema
+
+        fieldmap = get_fields(field_type_lookup, report)
+        return get_schema(_expected_tap_stream_id(report), fieldmap)
 
     # ── SdC system fields — all streams ──────────────────────────────────
 
@@ -255,4 +282,10 @@ class DcmAllFieldsTest(DcmBaseTest, unittest.TestCase):
                 for rec in written:
                     self.assertIn(SINGER_REPORT_FIELD, rec)
                     self.assertIn(REPORT_ID_FIELD, rec)
+
+    def test_datetime_fields_are_rfc3339_for_all_report_types(self):
+        """Any schema field marked date-time must emit RFC3339 values."""
+        for report in self.MOCK_REPORTS:
+            with self.subTest(report_type=report["type"]):
+                self._assert_datetime_fields_are_rfc3339(report)
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,0 +1,261 @@
+"""Mock integration tests — all report fields replicated for every DCM stream.
+
+Patches MediaIoBaseDownload and singer.write_record to capture written records
+and verify every dimension/metric column plus SdC system fields are present.
+No live credentials or network access required.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        get_report_headers,
+        build_sample_rows_for_report,
+        build_dcm_csv,
+        make_mock_downloader_class,
+        _expected_tap_stream_id,
+    )
+except ImportError:
+    from base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        get_report_headers,
+        build_sample_rows_for_report,
+        build_dcm_csv,
+        make_mock_downloader_class,
+        _expected_tap_stream_id,
+    )
+
+from tap_doubleclick_campaign_manager.schema import (
+    SINGER_REPORT_FIELD,
+    REPORT_ID_FIELD,
+    get_field_type_lookup,
+)
+
+
+# ---------------------------------------------------------------------------
+# Known missing / skipped fields
+# Add entries here only if a field is intentionally absent from mock data.
+# ---------------------------------------------------------------------------
+KNOWN_MISSING_FIELDS: dict[str, set[str]] = {}
+
+
+class TestDcmAllFields(DcmBaseTest, unittest.TestCase):
+    """Ensure every schema field appears in the records written during sync."""
+
+    # ── Generic assertion helper ─────────────────────────────────────────
+
+    def _assert_all_report_fields_present(self, report: dict, n_rows: int = 2):
+        """
+        Sync *report* with mocked data and assert every schema field appears
+        in at least one of the written Singer records.
+        """
+        tap_stream_id = _expected_tap_stream_id(report)
+        written = self._run_sync_for_report(report, n_rows=n_rows)
+
+        self.assertGreater(len(written), 0,
+                           f"No records written for stream '{tap_stream_id}'")
+
+        # Expected fields = report dimensions + metrics + SdC system fields
+        headers = get_report_headers(report)
+        expected_fields = set(headers) | {SINGER_REPORT_FIELD, REPORT_ID_FIELD}
+        known_missing = KNOWN_MISSING_FIELDS.get(tap_stream_id, set())
+        required = expected_fields - known_missing
+
+        actual_fields = set().union(*(set(r.keys()) for r in written))
+        missing = required - actual_fields
+
+        self.assertEqual(
+            missing,
+            set(),
+            msg=(
+                f"Stream '{tap_stream_id}': fields missing from written records: "
+                f"{missing}"
+            ),
+        )
+
+    # ── SdC system fields — all streams ──────────────────────────────────
+
+    def _assert_sdc_fields_present(self, report: dict):
+        written = self._run_sync_for_report(report)
+        for rec in written:
+            with self.subTest(report_id=report["id"]):
+                self.assertIn(SINGER_REPORT_FIELD, rec,
+                              msg=f"{SINGER_REPORT_FIELD} missing from record")
+                self.assertIn(REPORT_ID_FIELD, rec,
+                              msg=f"{REPORT_ID_FIELD} missing from record")
+
+    # ── STANDARD report ───────────────────────────────────────────────────
+
+    def test_standard_report_all_fields_present(self):
+        """STANDARD report: every dimension + metric + SdC field in records."""
+        self._assert_all_report_fields_present(STANDARD_REPORT)
+
+    def test_standard_report_sdc_fields_present(self):
+        self._assert_sdc_fields_present(STANDARD_REPORT)
+
+    def test_standard_report_sdc_report_id_is_integer(self):
+        """_sdc_report_id written to STANDARD records must be an integer."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            with self.subTest():
+                self.assertIsInstance(rec[REPORT_ID_FIELD], int)
+
+    def test_standard_report_sdc_report_time_is_string(self):
+        """_sdc_report_time written to STANDARD records must be a datetime string."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            with self.subTest():
+                self.assertIsInstance(rec[SINGER_REPORT_FIELD], str)
+
+    def test_standard_report_correct_number_of_records(self):
+        """sync_report must write exactly as many records as rows in the CSV."""
+        n = 3
+        written = self._run_sync_for_report(STANDARD_REPORT, n_rows=n)
+        self.assertEqual(len(written), n)
+
+    def test_standard_report_dimensions_present(self):
+        """STANDARD: 'date' and 'campaign' dimensions appear in every record."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            self.assertIn("date", rec)
+            self.assertIn("campaign", rec)
+
+    def test_standard_report_metrics_present(self):
+        """STANDARD: 'impressions' and 'clicks' metrics appear in every record."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            self.assertIn("impressions", rec)
+            self.assertIn("clicks", rec)
+
+    # ── FLOODLIGHT report ─────────────────────────────────────────────────
+
+    def test_floodlight_report_all_fields_present(self):
+        """FLOODLIGHT report: every dimension + metric + SdC field in records."""
+        self._assert_all_report_fields_present(FLOODLIGHT_REPORT)
+
+    def test_floodlight_report_sdc_fields_present(self):
+        self._assert_sdc_fields_present(FLOODLIGHT_REPORT)
+
+    def test_floodlight_report_dimensions_and_metrics_present(self):
+        """FLOODLIGHT: 'date', 'activity', 'totalConversions' in records."""
+        written = self._run_sync_for_report(FLOODLIGHT_REPORT)
+        for rec in written:
+            self.assertIn("date", rec)
+            self.assertIn("activity", rec)
+            self.assertIn("totalConversions", rec)
+
+    def test_floodlight_report_correct_record_count(self):
+        n = 2
+        written = self._run_sync_for_report(FLOODLIGHT_REPORT, n_rows=n)
+        self.assertEqual(len(written), n)
+
+    # ── CROSS_DIMENSION_REACH report ──────────────────────────────────────
+
+    def test_cross_dimension_reach_report_all_fields_present(self):
+        """CROSS_DIMENSION_REACH: every field in records."""
+        self._assert_all_report_fields_present(CROSS_DIMENSION_REACH_REPORT)
+
+    def test_cross_dimension_reach_report_sdc_fields_present(self):
+        self._assert_sdc_fields_present(CROSS_DIMENSION_REACH_REPORT)
+
+    def test_cross_dimension_reach_includes_overlap_metrics(self):
+        """CROSS_DIMENSION_REACH: 'overlapMetricNames' merged into columns."""
+        written = self._run_sync_for_report(CROSS_DIMENSION_REACH_REPORT)
+        for rec in written:
+            self.assertIn("uniqueReachIncrementalReach", rec)
+
+    # ── PATH_TO_CONVERSION report ─────────────────────────────────────────
+
+    def test_path_to_conversion_report_all_fields_present(self):
+        """PATH_TO_CONVERSION: every field in records."""
+        self._assert_all_report_fields_present(PATH_TO_CONVERSION_REPORT)
+
+    def test_path_to_conversion_report_sdc_fields_present(self):
+        self._assert_sdc_fields_present(PATH_TO_CONVERSION_REPORT)
+
+    def test_path_to_conversion_combines_conversion_and_interaction_dims(self):
+        """PATH_TO_CONVERSION: conversionDimensions + perInteractionDimensions merged."""
+        written = self._run_sync_for_report(PATH_TO_CONVERSION_REPORT)
+        for rec in written:
+            self.assertIn("date", rec)
+            self.assertIn("campaign", rec)
+
+    # ── REACH report ──────────────────────────────────────────────────────
+
+    def test_reach_report_all_fields_present(self):
+        """REACH report: every field in records."""
+        self._assert_all_report_fields_present(REACH_REPORT)
+
+    def test_reach_report_sdc_fields_present(self):
+        self._assert_sdc_fields_present(REACH_REPORT)
+
+    def test_reach_report_includes_reach_by_frequency_metrics(self):
+        """REACH: 'reachByFrequencyMetricNames' merged into columns."""
+        written = self._run_sync_for_report(REACH_REPORT)
+        for rec in written:
+            self.assertIn("reachByFrequency", rec)
+
+    # ── Data type integrity ───────────────────────────────────────────────
+
+    def test_standard_report_impressions_is_none_or_integer(self):
+        """'impressions' (long) in STANDARD records must be int or None."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            val = rec.get("impressions")
+            with self.subTest():
+                self.assertTrue(
+                    val is None or isinstance(val, int),
+                    msg=f"Expected int|None for impressions, got {type(val)}: {val!r}",
+                )
+
+    def test_standard_report_clicks_is_none_or_integer(self):
+        """'clicks' (long) in STANDARD records must be int or None."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            val = rec.get("clicks")
+            with self.subTest():
+                self.assertTrue(
+                    val is None or isinstance(val, int),
+                    msg=f"Expected int|None for clicks, got {type(val)}: {val!r}",
+                )
+
+    def test_sdc_report_id_matches_mock_report_id(self):
+        """_sdc_report_id in records must equal the actual mock report id."""
+        for report in self.MOCK_REPORTS:
+            written = self._run_sync_for_report(report)
+            for rec in written:
+                with self.subTest(report_id=report["id"]):
+                    self.assertEqual(rec[REPORT_ID_FIELD], report["id"])
+
+    # ── All 5 reports in a single parameterised sweep ─────────────────────
+
+    def test_all_report_types_write_at_least_one_record(self):
+        """Every supported DCM report type must produce ≥1 written record."""
+        for report in self.MOCK_REPORTS:
+            with self.subTest(report_type=report["type"], report_id=report["id"]):
+                written = self._run_sync_for_report(report, n_rows=1)
+                self.assertGreaterEqual(len(written), 1)
+
+    def test_all_report_types_include_sdc_fields(self):
+        """_sdc_report_time and _sdc_report_id must appear in all report types."""
+        for report in self.MOCK_REPORTS:
+            with self.subTest(report_type=report["type"]):
+                written = self._run_sync_for_report(report, n_rows=1)
+                for rec in written:
+                    self.assertIn(SINGER_REPORT_FIELD, rec)
+                    self.assertIn(REPORT_ID_FIELD, rec)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -50,7 +50,7 @@ from tap_doubleclick_campaign_manager.schema import (
 KNOWN_MISSING_FIELDS: dict[str, set[str]] = {}
 
 
-class TestDcmAllFields(DcmBaseTest, unittest.TestCase):
+class DcmAllFieldsTest(DcmBaseTest, unittest.TestCase):
     """Ensure every schema field appears in the records written during sync."""
 
     # ── Generic assertion helper ─────────────────────────────────────────

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,0 +1,201 @@
+"""Mock integration tests — automatic (SdC system) fields always present.
+
+Verifies that _sdc_report_time and _sdc_report_id are always injected into
+every written record regardless of the report type or field selection config.
+These SdC fields are the DCM equivalent of Singer 'automatic' fields and must
+be present even when a downstream target has suppressed other columns.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        make_mock_downloader_class,
+        build_dcm_csv,
+        _expected_tap_stream_id,
+    )
+except ImportError:
+    from base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        make_mock_downloader_class,
+        build_dcm_csv,
+        _expected_tap_stream_id,
+    )
+
+from tap_doubleclick_campaign_manager.schema import (
+    SINGER_REPORT_FIELD,
+    REPORT_ID_FIELD,
+    get_field_type_lookup,
+    get_fields,
+)
+from tap_doubleclick_campaign_manager.sync_reports import sync_report
+
+
+class TestDcmAutomaticFields(DcmBaseTest, unittest.TestCase):
+    """
+    Verify that _sdc_report_time and _sdc_report_id (automatic / system fields)
+    are always injected into records for every report type.
+    """
+
+    # SdC system fields that must always be present
+    AUTOMATIC_FIELDS = frozenset({SINGER_REPORT_FIELD, REPORT_ID_FIELD})
+
+    # ── Generic assertion helper ─────────────────────────────────────────
+
+    def _assert_automatic_fields_always_present(self, report: dict):
+        """
+        Sync *report* and assert that every written record contains both
+        automatic SdC system fields regardless of any other field selection.
+        """
+        written = self._run_sync_for_report(report, n_rows=2)
+        self.assertGreater(
+            len(written), 0,
+            msg=f"No records written for report type '{report['type']}'",
+        )
+        for rec in written:
+            with self.subTest(report_type=report["type"],
+                              record_fields=list(rec.keys())):
+                for auto_field in self.AUTOMATIC_FIELDS:
+                    self.assertIn(
+                        auto_field,
+                        rec,
+                        msg=(
+                            f"Automatic field '{auto_field}' missing from "
+                            f"'{report['type']}' record"
+                        ),
+                    )
+
+    # ── Per-report-type tests ─────────────────────────────────────────────
+
+    def test_standard_report_sdc_report_time_always_present(self):
+        """STANDARD: _sdc_report_time injected into every record."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            self.assertIn(SINGER_REPORT_FIELD, rec)
+
+    def test_standard_report_sdc_report_id_always_present(self):
+        """STANDARD: _sdc_report_id injected into every record."""
+        written = self._run_sync_for_report(STANDARD_REPORT)
+        for rec in written:
+            self.assertIn(REPORT_ID_FIELD, rec)
+
+    def test_floodlight_report_automatic_fields_always_present(self):
+        self._assert_automatic_fields_always_present(FLOODLIGHT_REPORT)
+
+    def test_cross_dimension_reach_report_automatic_fields_always_present(self):
+        self._assert_automatic_fields_always_present(CROSS_DIMENSION_REACH_REPORT)
+
+    def test_path_to_conversion_report_automatic_fields_always_present(self):
+        self._assert_automatic_fields_always_present(PATH_TO_CONVERSION_REPORT)
+
+    def test_reach_report_automatic_fields_always_present(self):
+        self._assert_automatic_fields_always_present(REACH_REPORT)
+
+    # ── SdC field value contracts ─────────────────────────────────────────
+
+    def test_sdc_report_id_is_int_for_all_report_types(self):
+        """_sdc_report_id must be an integer for every report type."""
+        for report in self.MOCK_REPORTS:
+            written = self._run_sync_for_report(report, n_rows=1)
+            for rec in written:
+                with self.subTest(report_type=report["type"]):
+                    self.assertIsInstance(
+                        rec[REPORT_ID_FIELD], int,
+                        msg=f"_sdc_report_id should be int, got {type(rec[REPORT_ID_FIELD])}",
+                    )
+
+    def test_sdc_report_time_is_str_for_all_report_types(self):
+        """_sdc_report_time must be a string (ISO-8601 datetime) for every report type."""
+        for report in self.MOCK_REPORTS:
+            written = self._run_sync_for_report(report, n_rows=1)
+            for rec in written:
+                with self.subTest(report_type=report["type"]):
+                    self.assertIsInstance(
+                        rec[SINGER_REPORT_FIELD], str,
+                        msg=f"_sdc_report_time should be str, got "
+                            f"{type(rec[SINGER_REPORT_FIELD])}",
+                    )
+
+    def test_sdc_report_id_matches_report_id(self):
+        """_sdc_report_id must equal the actual report id in the config."""
+        for report in self.MOCK_REPORTS:
+            written = self._run_sync_for_report(report, n_rows=1)
+            for rec in written:
+                with self.subTest(report_id=report["id"]):
+                    self.assertEqual(
+                        rec[REPORT_ID_FIELD],
+                        report["id"],
+                        msg=(
+                            f"_sdc_report_id {rec[REPORT_ID_FIELD]} != "
+                            f"report id {report['id']}"
+                        ),
+                    )
+
+    def test_sdc_report_time_contains_date_component(self):
+        """_sdc_report_time must look like a datetime (contains 'T' separator)."""
+        written = self._run_sync_for_report(STANDARD_REPORT, n_rows=1)
+        for rec in written:
+            self.assertIn(
+                "T",
+                rec[SINGER_REPORT_FIELD],
+                msg="_sdc_report_time does not look like an ISO-8601 datetime",
+            )
+
+    # ── Empty-CSV edge case: SdC fields still defined in schema ──────────
+
+    def test_sdc_fields_in_schema_for_empty_csv(self):
+        """Even if no data rows are emitted, schema must declare SdC fields."""
+        from tap_doubleclick_campaign_manager.schema import get_schema
+
+        for report in self.MOCK_REPORTS:
+            field_type_lookup = get_field_type_lookup()
+            fieldmap = get_fields(field_type_lookup, report)
+            schema = get_schema(_expected_tap_stream_id(report), fieldmap)
+            with self.subTest(report_type=report["type"]):
+                self.assertIn(SINGER_REPORT_FIELD, schema["properties"])
+                self.assertIn(REPORT_ID_FIELD, schema["properties"])
+
+    # ── Minimal CSV (one row): automatic fields survive all transforms ────
+
+    def test_automatic_fields_survive_single_row_csv(self):
+        """With a 1-row CSV, automatic fields must still appear in the record."""
+        for report in self.MOCK_REPORTS:
+            with self.subTest(report_type=report["type"]):
+                written = self._run_sync_for_report(report, n_rows=1)
+                self.assertEqual(len(written), 1)
+                for auto_field in self.AUTOMATIC_FIELDS:
+                    self.assertIn(auto_field, written[0])
+
+    # ── Grand Total row not emitted as a record ───────────────────────────
+
+    def test_grand_total_row_excluded_from_records(self):
+        """The 'Grand Total:' CSV footer row must never appear as a Singer record."""
+        for report in self.MOCK_REPORTS:
+            with self.subTest(report_type=report["type"]):
+                written = self._run_sync_for_report(report, n_rows=2)
+                # If Grand Total were included, the first field value would start with
+                # "Grand Total:" — this must not occur.
+                for rec in written:
+                    for val in rec.values():
+                        if isinstance(val, str):
+                            self.assertFalse(
+                                val.startswith("Grand Total:"),
+                                msg="Grand Total marker appeared in a record",
+                            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -44,7 +44,7 @@ from tap_doubleclick_campaign_manager.schema import (
 from tap_doubleclick_campaign_manager.sync_reports import sync_report
 
 
-class TestDcmAutomaticFields(DcmBaseTest, unittest.TestCase):
+class DcmAutomaticFieldsTest(DcmBaseTest, unittest.TestCase):
     """
     Verify that _sdc_report_time and _sdc_report_id (automatic / system fields)
     are always injected into records for every report type.

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -196,6 +196,3 @@ class DcmAutomaticFieldsTest(DcmBaseTest, unittest.TestCase):
                                 msg="Grand Total marker appeared in a record",
                             )
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,288 @@
+"""Mock integration tests for tap-doubleclick-campaign-manager stream discovery.
+
+Calls discover_streams() with a mocked Google API service — no real credentials
+or network access required.  Verifies catalog structure for all five DCM report
+types: STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH.
+"""
+import unittest
+from singer import metadata
+
+try:
+    from .base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        _expected_tap_stream_id,
+    )
+except ImportError:
+    from base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        _expected_tap_stream_id,
+    )
+
+from tap_doubleclick_campaign_manager.discover import discover_streams
+from tap_doubleclick_campaign_manager.schema import SINGER_REPORT_FIELD, REPORT_ID_FIELD
+
+
+class TestDcmDiscovery(DcmBaseTest, unittest.TestCase):
+    """Verify discover_streams() builds the correct Singer Catalog."""
+
+    # ── Stream presence ──────────────────────────────────────────────────
+
+    def test_discovery_returns_all_five_report_type_streams(self):
+        """discover_streams must return one entry for each mocked report."""
+        catalog_dict = self._discover()
+        discovered_ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertEqual(discovered_ids, self.expected_tap_stream_ids())
+
+    def test_discovery_stream_count_matches_report_count(self):
+        """Catalog entry count must equal the number of mock reports."""
+        catalog_dict = self._discover()
+        self.assertEqual(len(catalog_dict["streams"]), self.expected_stream_count())
+
+    def test_discovery_stream_name_equals_tap_stream_id_without_suffix(self):
+        """stream field (display name) must be the sanitized report name only."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                # tap_stream_id = {stream}_{report_id}, so strip the numeric suffix
+                expected_stream = stream["tap_stream_id"].rsplit("_", 1)[0]
+                self.assertEqual(stream["stream"], expected_stream)
+
+    def test_discovery_tap_stream_id_contains_report_id(self):
+        """tap_stream_id must end with the numeric report id."""
+        catalog_dict = self._discover()
+        report_ids = {str(r["id"]) for r in self.MOCK_REPORTS}
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                suffix = stream["tap_stream_id"].rsplit("_", 1)[-1]
+                self.assertIn(suffix, report_ids)
+
+    def test_discovery_sorts_streams_by_report_id(self):
+        """Streams in the returned catalog must be sorted ascending by report id."""
+        catalog_dict = self._discover()
+        stream_ids_in_order = [s["tap_stream_id"] for s in catalog_dict["streams"]]
+        # extract numeric suffix and verify ascending order
+        suffixes = [int(sid.rsplit("_", 1)[-1]) for sid in stream_ids_in_order]
+        self.assertEqual(suffixes, sorted(suffixes))
+
+    # ── Schema integrity ─────────────────────────────────────────────────
+
+    def test_discovery_schema_has_properties(self):
+        """Every stream schema must have at least one property."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                props = stream["schema"].get("properties", {})
+                self.assertGreater(len(props), 0)
+
+    def test_discovery_schema_contains_sdc_report_time(self):
+        """Every stream schema must include the _sdc_report_time SdC field."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertIn(SINGER_REPORT_FIELD, stream["schema"]["properties"])
+
+    def test_discovery_schema_contains_sdc_report_id(self):
+        """Every stream schema must include the _sdc_report_id SdC field."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertIn(REPORT_ID_FIELD, stream["schema"]["properties"])
+
+    def test_discovery_sdc_report_time_is_datetime(self):
+        """_sdc_report_time property must have format: date-time."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                prop = stream["schema"]["properties"][SINGER_REPORT_FIELD]
+                self.assertEqual(prop.get("format"), "date-time")
+
+    def test_discovery_sdc_report_id_is_integer(self):
+        """_sdc_report_id property must have type: integer."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                prop = stream["schema"]["properties"][REPORT_ID_FIELD]
+                self.assertIn("integer", prop.get("type", []))
+
+    def test_discovery_schema_includes_dimension_and_metric_fields(self):
+        """Schema properties must include every dimension and metric from the report."""
+        catalog_dict = self._discover()
+        # Check the STANDARD report as the reference case
+        std_stream = next(
+            s for s in catalog_dict["streams"]
+            if str(STANDARD_REPORT["id"]) in s["tap_stream_id"]
+        )
+        props = std_stream["schema"]["properties"]
+        for col in ("date", "campaign", "impressions", "clicks"):
+            with self.subTest(column=col):
+                self.assertIn(col, props)
+
+    # ── Metadata assertions ───────────────────────────────────────────────
+
+    def test_discovery_forced_replication_method_is_full_table(self):
+        """forced-replication-method must be FULL_TABLE for every stream."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                root_meta = next(
+                    m for m in stream["metadata"] if m["breadcrumb"] == []
+                )
+                self.assertEqual(
+                    root_meta["metadata"]["forced-replication-method"],
+                    "FULL_TABLE",
+                )
+
+    def test_discovery_report_id_in_root_metadata(self):
+        """The DCM report-id must be stored in root metadata for each stream."""
+        catalog_dict = self._discover()
+        report_ids = {r["id"] for r in self.MOCK_REPORTS}
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                root_meta = next(
+                    m for m in stream["metadata"] if m["breadcrumb"] == []
+                )
+                rid = root_meta["metadata"][
+                    "tap-doubleclick-campaign-manager.report-id"
+                ]
+                self.assertIn(rid, report_ids)
+
+    def test_discovery_every_property_has_inclusion_automatic(self):
+        """Every schema property must have inclusion=automatic in metadata."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                prop_meta = [
+                    m for m in stream["metadata"]
+                    if len(m["breadcrumb"]) == 2 and m["breadcrumb"][0] == "properties"
+                ]
+                for m in prop_meta:
+                    with self.subTest(breadcrumb=m["breadcrumb"]):
+                        self.assertEqual(m["metadata"]["inclusion"], "automatic")
+
+    def test_discovery_metadata_list_is_not_empty(self):
+        """Every stream catalog entry must have at least one metadata dict."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertGreater(len(stream["metadata"]), 0)
+
+    def test_discovery_no_primary_keys(self):
+        """DCM report streams have no natural primary keys (empty key_properties)."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertEqual(stream.get("key_properties", []), [])
+
+    # ── All five report types produce streams ─────────────────────────────
+
+    def test_standard_report_produces_stream(self):
+        catalog_dict = self._discover()
+        ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertIn(_expected_tap_stream_id(STANDARD_REPORT), ids)
+
+    def test_floodlight_report_produces_stream(self):
+        catalog_dict = self._discover()
+        ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertIn(_expected_tap_stream_id(FLOODLIGHT_REPORT), ids)
+
+    def test_cross_dimension_reach_report_produces_stream(self):
+        catalog_dict = self._discover()
+        ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertIn(_expected_tap_stream_id(CROSS_DIMENSION_REACH_REPORT), ids)
+
+    def test_path_to_conversion_report_produces_stream(self):
+        catalog_dict = self._discover()
+        ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertIn(_expected_tap_stream_id(PATH_TO_CONVERSION_REPORT), ids)
+
+    def test_reach_report_produces_stream(self):
+        catalog_dict = self._discover()
+        ids = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertIn(_expected_tap_stream_id(REACH_REPORT), ids)
+
+    # ── Field-type schema mapping ─────────────────────────────────────────
+
+    def test_long_fields_have_integer_type_in_schema(self):
+        """Fields with DCM type 'long' must map to JSON Schema 'integer'."""
+        catalog_dict = self._discover()
+        # 'impressions' is type 'long' in the field lookup
+        std_stream = next(
+            s for s in catalog_dict["streams"]
+            if str(STANDARD_REPORT["id"]) in s["tap_stream_id"]
+        )
+        impressions_type = std_stream["schema"]["properties"]["impressions"]["type"]
+        self.assertIn("integer", impressions_type)
+
+    def test_string_fields_have_string_type_in_schema(self):
+        """Fields with DCM type 'string' must map to JSON Schema 'string'."""
+        catalog_dict = self._discover()
+        std_stream = next(
+            s for s in catalog_dict["streams"]
+            if str(STANDARD_REPORT["id"]) in s["tap_stream_id"]
+        )
+        date_type = std_stream["schema"]["properties"]["date"]["type"]
+        self.assertIn("string", date_type)
+
+    def test_schema_types_include_null(self):
+        """All user-defined field types must allow null (Singer convention)."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                props = stream["schema"]["properties"]
+                for field_name, field_schema in props.items():
+                    # SdC system fields use a plain non-null type; skip them
+                    if field_name in (SINGER_REPORT_FIELD, REPORT_ID_FIELD):
+                        continue
+                    with self.subTest(field=field_name):
+                        self.assertIn("null", field_schema.get("type", []))
+
+    # ── Empty report list edge case ───────────────────────────────────────
+
+    def test_empty_report_list_returns_empty_catalog(self):
+        """discover_streams with no reports should return an empty catalog."""
+        service = build_mock_service(reports_pages=[[]])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(len(catalog_dict["streams"]), 0)
+
+    # ── Name sanitization ─────────────────────────────────────────────────
+
+    def test_report_name_with_spaces_sanitized(self):
+        """Spaces in report names must be replaced with underscores."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            self.assertNotIn(" ", stream["stream"])
+
+    def test_report_name_with_hyphens_sanitized(self):
+        """Hyphens in report names must be replaced with underscores."""
+        from tap_doubleclick_campaign_manager.discover import sanitize_name
+        self.assertEqual(sanitize_name("My-Report-Name"), "my_report_name")
+
+    def test_stream_name_lowercase(self):
+        """All stream names must be lowercase."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertEqual(stream["stream"], stream["stream"].lower())
+
+    def test_stream_alias_equals_stream(self):
+        """stream_alias must equal stream (used by Singer for table naming)."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertEqual(stream.get("stream_alias"), stream["stream"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -305,6 +305,3 @@ class DcmDiscoveryTest(DcmBaseTest, unittest.TestCase):
             with self.subTest(tap_stream_id=stream["tap_stream_id"]):
                 self.assertEqual(stream.get("stream_alias"), stream["stream"])
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -34,7 +34,7 @@ from tap_doubleclick_campaign_manager.discover import discover_streams
 from tap_doubleclick_campaign_manager.schema import SINGER_REPORT_FIELD, REPORT_ID_FIELD
 
 
-class TestDcmDiscovery(DcmBaseTest, unittest.TestCase):
+class DcmDiscoveryTest(DcmBaseTest, unittest.TestCase):
     """Verify discover_streams() builds the correct Singer Catalog."""
 
     # ── Stream presence ──────────────────────────────────────────────────
@@ -143,6 +143,28 @@ class TestDcmDiscovery(DcmBaseTest, unittest.TestCase):
                     root_meta["metadata"]["forced-replication-method"],
                     "FULL_TABLE",
                 )
+
+    def test_all_streams_are_full_table(self):
+        """expected_metadata() must report FULL_TABLE for every DCM stream."""
+        for stream_id, meta in self.expected_metadata().items():
+            with self.subTest(stream=stream_id):
+                self.assertEqual(meta[self.REPLICATION_METHOD], self.FULL_TABLE)
+
+    def test_all_streams_have_no_replication_keys(self):
+        """All DCM streams are FULL_TABLE — no replication keys expected."""
+        for stream_id, meta in self.expected_metadata().items():
+            with self.subTest(stream=stream_id):
+                self.assertEqual(meta[self.REPLICATION_KEYS], set())
+
+    def test_full_table_streams_do_not_obey_start_date(self):
+        """All DCM streams must have OBEYS_START_DATE=False in expected_metadata."""
+        for stream_id, meta in self.expected_metadata().items():
+            with self.subTest(stream=stream_id):
+                self.assertFalse(meta[self.OBEYS_START_DATE])
+
+    def test_full_table_streams_set_matches_all_streams(self):
+        """full_table_streams() must return every expected stream."""
+        self.assertEqual(self.full_table_streams(), self.expected_stream_names())
 
     def test_discovery_report_id_in_root_metadata(self):
         """The DCM report-id must be stored in root metadata for each stream."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -4,6 +4,7 @@ Calls discover_streams() with a mocked Google API service — no real credential
 or network access required.  Verifies catalog structure for all five DCM report
 types: STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH.
 """
+import re
 import unittest
 from singer import metadata
 
@@ -58,6 +59,13 @@ class DcmDiscoveryTest(DcmBaseTest, unittest.TestCase):
                 # tap_stream_id = {stream}_{report_id}, so strip the numeric suffix
                 expected_stream = stream["tap_stream_id"].rsplit("_", 1)[0]
                 self.assertEqual(stream["stream"], expected_stream)
+
+    def test_discovery_stream_names_match_regex(self):
+        """Stream names must be lowercase alphanumerics/underscores only."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                self.assertRegex(stream["stream"], r"^[a-z0-9_]+$")
 
     def test_discovery_tap_stream_id_contains_report_id(self):
         """tap_stream_id must end with the numeric report id."""
@@ -199,6 +207,28 @@ class DcmDiscoveryTest(DcmBaseTest, unittest.TestCase):
         for stream in catalog_dict["streams"]:
             with self.subTest(tap_stream_id=stream["tap_stream_id"]):
                 self.assertGreater(len(stream["metadata"]), 0)
+
+    def test_discovery_exactly_one_top_level_breadcrumb(self):
+        """Every stream must have exactly one top-level metadata breadcrumb."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                top_level = [m for m in stream["metadata"] if m["breadcrumb"] == []]
+                self.assertEqual(len(top_level), 1)
+
+    def test_discovery_has_no_duplicate_property_metadata_entries(self):
+        """Property metadata breadcrumbs must not contain duplicates."""
+        catalog_dict = self._discover()
+        for stream in catalog_dict["streams"]:
+            with self.subTest(tap_stream_id=stream["tap_stream_id"]):
+                property_breadcrumbs = [
+                    tuple(m["breadcrumb"]) for m in stream["metadata"]
+                    if m["breadcrumb"] != []
+                ]
+                self.assertEqual(
+                    len(property_breadcrumbs),
+                    len(set(property_breadcrumbs)),
+                )
 
     def test_discovery_no_primary_keys(self):
         """DCM report streams have no natural primary keys (empty key_properties)."""

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,261 @@
+"""Mock integration tests — pagination for tap-doubleclick-campaign-manager.
+
+Verifies that discover_streams() correctly fetches ALL pages from the
+reports.list endpoint when the API returns a nextPageToken, and that every
+report from every page is registered as a stream in the final catalog.
+
+DCM's reports.list API uses cursor-based pagination (nextPageToken / pageToken).
+The current implementation (discover.py) has been updated to page through all
+results.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+try:
+    from .base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        _expected_tap_stream_id,
+    )
+except ImportError:
+    from base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        _expected_tap_stream_id,
+    )
+
+from tap_doubleclick_campaign_manager.discover import discover_streams
+
+
+class TestDcmDiscoveryPagination(DcmBaseTest, unittest.TestCase):
+    """
+    Verify discover_streams() pages through all available reports via
+    nextPageToken, building a complete catalog.
+    """
+
+    # ── Two-page discovery ────────────────────────────────────────────────
+
+    def test_two_page_discovery_returns_all_streams(self):
+        """Reports split across 2 pages must all appear in the catalog."""
+        page1 = [STANDARD_REPORT, FLOODLIGHT_REPORT]
+        page2 = [CROSS_DIMENSION_REACH_REPORT]
+
+        service = build_mock_service(reports_pages=[page1, page2])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        discovered = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        expected = {
+            _expected_tap_stream_id(STANDARD_REPORT),
+            _expected_tap_stream_id(FLOODLIGHT_REPORT),
+            _expected_tap_stream_id(CROSS_DIMENSION_REACH_REPORT),
+        }
+        self.assertEqual(discovered, expected)
+
+    def test_two_page_discovery_stream_count(self):
+        """Catalog must contain exactly 3 entries when 3 reports span 2 pages."""
+        page1 = [STANDARD_REPORT, FLOODLIGHT_REPORT]
+        page2 = [CROSS_DIMENSION_REACH_REPORT]
+
+        service = build_mock_service(reports_pages=[page1, page2])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        self.assertEqual(len(catalog_dict["streams"]), 3)
+
+    def test_two_page_discovery_calls_list_twice(self):
+        """Two pages must result in exactly 2 calls to list().execute()."""
+        page1 = [STANDARD_REPORT]
+        page2 = [FLOODLIGHT_REPORT]
+
+        service = build_mock_service(reports_pages=[page1, page2])
+        discover_streams(service, self.MOCK_CONFIG)
+
+        execute_mock = service.reports.return_value.list.return_value.execute
+        self.assertEqual(execute_mock.call_count, 2)
+
+    # ── Three-page discovery ──────────────────────────────────────────────
+
+    def test_three_page_discovery_returns_all_five_streams(self):
+        """Reports split across 3 pages — all five must appear in catalog."""
+        page1 = [STANDARD_REPORT, FLOODLIGHT_REPORT]
+        page2 = [CROSS_DIMENSION_REACH_REPORT, PATH_TO_CONVERSION_REPORT]
+        page3 = [REACH_REPORT]
+
+        service = build_mock_service(reports_pages=[page1, page2, page3])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        discovered = {s["tap_stream_id"] for s in catalog_dict["streams"]}
+        self.assertEqual(discovered, self.expected_tap_stream_ids())
+
+    def test_three_page_discovery_calls_list_three_times(self):
+        """Three pages must result in exactly 3 calls to list().execute()."""
+        page1 = [STANDARD_REPORT]
+        page2 = [FLOODLIGHT_REPORT]
+        page3 = [CROSS_DIMENSION_REACH_REPORT]
+
+        service = build_mock_service(reports_pages=[page1, page2, page3])
+        discover_streams(service, self.MOCK_CONFIG)
+
+        execute_mock = service.reports.return_value.list.return_value.execute
+        self.assertEqual(execute_mock.call_count, 3)
+
+    # ── Single-page (no pagination) ───────────────────────────────────────
+
+    def test_single_page_calls_list_once(self):
+        """When there is no nextPageToken one call to list().execute() is enough."""
+        service = build_mock_service(reports_pages=[[STANDARD_REPORT]])
+        discover_streams(service, self.MOCK_CONFIG)
+
+        execute_mock = service.reports.return_value.list.return_value.execute
+        self.assertEqual(execute_mock.call_count, 1)
+
+    def test_single_page_discovery_returns_correct_stream(self):
+        """Single-page discovery must still build the correct catalog entry."""
+        service = build_mock_service(reports_pages=[[STANDARD_REPORT]])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        self.assertEqual(len(catalog_dict["streams"]), 1)
+        self.assertEqual(
+            catalog_dict["streams"][0]["tap_stream_id"],
+            _expected_tap_stream_id(STANDARD_REPORT),
+        )
+
+    # ── Empty-page handling ───────────────────────────────────────────────
+
+    def test_empty_first_page_returns_empty_catalog(self):
+        """An empty first page with no nextPageToken produces an empty catalog."""
+        service = build_mock_service(reports_pages=[[]])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(len(catalog_dict["streams"]), 0)
+
+    def test_page_with_no_items_key_returns_empty(self):
+        """A response dict missing the 'items' key is handled gracefully."""
+        service = MagicMock()
+        # Simulate a page with no 'items' key (empty response)
+        service.reports.return_value.list.return_value.execute.return_value = {}
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(len(catalog_dict["streams"]), 0)
+
+    # ── Sorting preserved across pages ───────────────────────────────────
+
+    def test_streams_sorted_by_report_id_across_pages(self):
+        """Streams must be globally sorted by report id even when split across pages."""
+        # Deliberately put the higher-id report on page 1
+        page1 = [FLOODLIGHT_REPORT]   # id=1002
+        page2 = [STANDARD_REPORT]     # id=1001 — lower id on page 2
+
+        service = build_mock_service(reports_pages=[page1, page2])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        ids_in_order = [s["tap_stream_id"] for s in catalog_dict["streams"]]
+        numeric_ids = [int(sid.rsplit("_", 1)[-1]) for sid in ids_in_order]
+        self.assertEqual(numeric_ids, sorted(numeric_ids))
+
+    # ── nextPageToken pass-through ────────────────────────────────────────
+
+    def test_next_page_token_passed_to_second_request(self):
+        """The pageToken returned on page 1 must be forwarded to the page 2 request."""
+        page1 = [STANDARD_REPORT]
+        page2 = [FLOODLIGHT_REPORT]
+        token = "abc_test_token"
+
+        service = MagicMock()
+        execute_mock = service.reports.return_value.list.return_value.execute
+        execute_mock.side_effect = [
+            {"items": page1, "nextPageToken": token},
+            {"items": page2},
+        ]
+
+        discover_streams(service, self.MOCK_CONFIG)
+
+        # Verify list() was called twice
+        list_mock = service.reports.return_value.list
+        self.assertEqual(list_mock.call_count, 2)
+
+        # Second call must include pageToken
+        second_call_kwargs = list_mock.call_args_list[1][1]
+        self.assertIn("pageToken", second_call_kwargs,
+                      msg="Second call to list() must include pageToken kwarg")
+        self.assertEqual(second_call_kwargs["pageToken"], token)
+
+    def test_first_request_does_not_include_page_token(self):
+        """The first request to list() must NOT include a pageToken."""
+        service = build_mock_service(reports_pages=[[STANDARD_REPORT]])
+        discover_streams(service, self.MOCK_CONFIG)
+
+        list_mock = service.reports.return_value.list
+        first_call_kwargs = list_mock.call_args_list[0][1]
+        self.assertNotIn("pageToken", first_call_kwargs)
+
+    # ── Large page simulation ─────────────────────────────────────────────
+
+    def test_many_reports_on_single_page(self):
+        """A single page with 20 reports produces exactly 20 catalog entries."""
+        reports = []
+        for i in range(20):
+            reports.append({
+                "id": 2000 + i,
+                "name": f"Bulk Report {i:02d}",
+                "type": "STANDARD",
+                "criteria": {
+                    "dimensions": [{"name": "date"}],
+                    "metricNames": ["impressions"],
+                },
+            })
+        service = build_mock_service(reports_pages=[reports])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(len(catalog_dict["streams"]), 20)
+
+    def test_reports_spread_across_five_single_item_pages(self):
+        """5 pages of 1 report each must produce exactly 5 catalog entries."""
+        pages = [[r] for r in self.MOCK_REPORTS]
+        service = build_mock_service(reports_pages=pages)
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(len(catalog_dict["streams"]), 5)
+
+        execute_mock = service.reports.return_value.list.return_value.execute
+        self.assertEqual(execute_mock.call_count, 5)
+
+    # ── Duplicate report names across pages don't collide ─────────────────
+
+    def test_duplicate_name_reports_get_unique_tap_stream_ids(self):
+        """Two reports with the same name but different IDs must produce 2 streams."""
+        report_a = {
+            "id": 5001,
+            "name": "Sales Report",
+            "type": "STANDARD",
+            "criteria": {
+                "dimensions": [{"name": "date"}],
+                "metricNames": ["impressions"],
+            },
+        }
+        report_b = {
+            "id": 5002,
+            "name": "Sales Report",
+            "type": "STANDARD",
+            "criteria": {
+                "dimensions": [{"name": "date"}],
+                "metricNames": ["clicks"],
+            },
+        }
+        service = build_mock_service(reports_pages=[[report_a], [report_b]])
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+
+        tap_stream_ids = [s["tap_stream_id"] for s in catalog_dict["streams"]]
+        self.assertEqual(len(set(tap_stream_ids)), 2,
+                         msg="Same-name reports must have distinct tap_stream_ids")
+        self.assertIn("sales_report_5001", tap_stream_ids)
+        self.assertIn("sales_report_5002", tap_stream_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -256,6 +256,3 @@ class DcmPaginationTest(DcmBaseTest, unittest.TestCase):
         self.assertIn("sales_report_5001", tap_stream_ids)
         self.assertIn("sales_report_5002", tap_stream_ids)
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -196,6 +196,32 @@ class DcmPaginationTest(DcmBaseTest, unittest.TestCase):
         first_call_kwargs = list_mock.call_args_list[0][1]
         self.assertNotIn("pageToken", first_call_kwargs)
 
+    def test_stops_after_page_with_no_next_token(self):
+        """Pagination must stop when response has no nextPageToken."""
+        service = MagicMock()
+        execute_mock = service.reports.return_value.list.return_value.execute
+        execute_mock.side_effect = [
+            {"items": [STANDARD_REPORT], "nextPageToken": "page_1"},
+            {"items": [FLOODLIGHT_REPORT]},
+        ]
+
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(execute_mock.call_count, 2)
+        self.assertEqual(len(catalog_dict["streams"]), 2)
+
+    def test_empty_page_with_repeated_token_does_not_loop_forever(self):
+        """A repeated token on an empty page must terminate pagination safely."""
+        service = MagicMock()
+        execute_mock = service.reports.return_value.list.return_value.execute
+        execute_mock.side_effect = [
+            {"items": [STANDARD_REPORT], "nextPageToken": "same_token"},
+            {"items": [], "nextPageToken": "same_token"},
+        ]
+
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        self.assertEqual(execute_mock.call_count, 2)
+        self.assertEqual(len(catalog_dict["streams"]), 1)
+
     # ── Large page simulation ─────────────────────────────────────────────
 
     def test_many_reports_on_single_page(self):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -37,7 +37,7 @@ except ImportError:
 from tap_doubleclick_campaign_manager.discover import discover_streams
 
 
-class TestDcmDiscoveryPagination(DcmBaseTest, unittest.TestCase):
+class DcmPaginationTest(DcmBaseTest, unittest.TestCase):
     """
     Verify discover_streams() pages through all available reports via
     nextPageToken, building a complete catalog.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,503 @@
+"""Mock integration tests — full end-to-end sync pipeline for tap-dcm.
+
+Covers the complete sync lifecycle:
+  1. discover_streams() → build catalog
+  2. sync_reports() → selects streams, calls sync_report() per stream
+  3. sync_report() → run report, poll status, download CSV, write records
+
+All Google API calls are replaced by MagicMock objects; no real credentials
+or network access are required.  CSV data is injected via a mock
+MediaIoBaseDownload class.
+"""
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+from singer import metadata as singer_metadata
+from singer.catalog import Catalog, CatalogEntry, Schema
+
+try:
+    from .base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        make_mock_downloader_class,
+        build_dcm_csv,
+        get_report_headers,
+        build_sample_rows_for_report,
+        _expected_tap_stream_id,
+    )
+except ImportError:
+    from base import (
+        DcmBaseTest,
+        STANDARD_REPORT,
+        FLOODLIGHT_REPORT,
+        CROSS_DIMENSION_REACH_REPORT,
+        PATH_TO_CONVERSION_REPORT,
+        REACH_REPORT,
+        build_mock_service,
+        make_mock_downloader_class,
+        build_dcm_csv,
+        get_report_headers,
+        build_sample_rows_for_report,
+        _expected_tap_stream_id,
+    )
+
+from tap_doubleclick_campaign_manager.sync_reports import sync_report, sync_reports
+from tap_doubleclick_campaign_manager.schema import (
+    SINGER_REPORT_FIELD,
+    REPORT_ID_FIELD,
+    get_field_type_lookup,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_catalog_entry(report: dict, selected: bool = True) -> CatalogEntry:
+    """Build a single CatalogEntry for the given mock report."""
+    tap_stream_id = _expected_tap_stream_id(report)
+    meta = [
+        {
+            "breadcrumb": [],
+            "metadata": {
+                "tap-doubleclick-campaign-manager.report-id": report["id"],
+                "forced-replication-method": "FULL_TABLE",
+                "selected": selected,
+            },
+        }
+    ]
+    return CatalogEntry(
+        stream=tap_stream_id.rsplit("_", 1)[0],
+        stream_alias=tap_stream_id.rsplit("_", 1)[0],
+        tap_stream_id=tap_stream_id,
+        key_properties=[],
+        schema=Schema.from_dict({"type": "object", "properties": {}}),
+        metadata=meta,
+    )
+
+
+def _make_catalog(reports: list[dict], selected: bool = True) -> Catalog:
+    return Catalog([_make_catalog_entry(r, selected=selected) for r in reports])
+
+
+# ---------------------------------------------------------------------------
+# sync_report() tests
+# ---------------------------------------------------------------------------
+
+class TestDcmSyncReport(DcmBaseTest, unittest.TestCase):
+    """Test the sync_report() function in isolation with mocked service."""
+
+    # ── Records are written ───────────────────────────────────────────────
+
+    def test_sync_report_writes_records_for_standard_report(self):
+        """sync_report() must write at least one Singer record for STANDARD."""
+        written = self._run_sync_for_report(STANDARD_REPORT, n_rows=2)
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_sync_report_writes_records_for_floodlight_report(self):
+        written = self._run_sync_for_report(FLOODLIGHT_REPORT, n_rows=2)
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_sync_report_writes_records_for_cross_dimension_reach(self):
+        written = self._run_sync_for_report(CROSS_DIMENSION_REACH_REPORT, n_rows=2)
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_sync_report_writes_records_for_path_to_conversion(self):
+        written = self._run_sync_for_report(PATH_TO_CONVERSION_REPORT, n_rows=2)
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_sync_report_writes_records_for_reach(self):
+        written = self._run_sync_for_report(REACH_REPORT, n_rows=2)
+        self.assertGreaterEqual(len(written), 1)
+
+    # ── Singer schema is emitted ─────────────────────────────────────────
+
+    def test_sync_report_writes_schema_before_records(self):
+        """sync_report() must call singer.write_schema before any write_record."""
+        field_type_lookup = get_field_type_lookup()
+        csv_bytes = self._csv_for_report(STANDARD_REPORT, n_rows=1)
+        service = build_mock_service(
+            reports_pages=[[STANDARD_REPORT]],
+            report_details=STANDARD_REPORT,
+        )
+        report_config = {
+            "report_id": STANDARD_REPORT["id"],
+            "stream_name": _expected_tap_stream_id(STANDARD_REPORT),
+            "stream_alias": _expected_tap_stream_id(STANDARD_REPORT),
+            "metadata": {},
+        }
+        call_order = []
+
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema",
+                   side_effect=lambda *a, **kw: call_order.append("schema")), \
+             patch("singer.write_record",
+                   side_effect=lambda *a, **kw: call_order.append("record")), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+        schema_idx = call_order.index("schema")
+        first_record_idx = call_order.index("record")
+        self.assertLess(schema_idx, first_record_idx,
+                        "write_schema must be called before the first write_record")
+
+    # ── File status polling ───────────────────────────────────────────────
+
+    @patch("time.sleep", return_value=None)
+    def test_queued_status_retries_until_available(self, mock_sleep):
+        """QUEUED status triggers a sleep/retry loop before the file is processed."""
+        field_type_lookup = get_field_type_lookup()
+        csv_bytes = self._csv_for_report(STANDARD_REPORT, n_rows=1)
+
+        service = build_mock_service(
+            reports_pages=[[STANDARD_REPORT]],
+            report_details=STANDARD_REPORT,
+        )
+        # Override files().get().execute() to return QUEUED then REPORT_AVAILABLE
+        statuses = iter(["QUEUED", "REPORT_AVAILABLE"])
+        service.files.return_value.get.return_value.execute.side_effect = (
+            lambda: {"status": next(statuses), "id": "file_001"}
+        )
+
+        report_config = {
+            "report_id": STANDARD_REPORT["id"],
+            "stream_name": _expected_tap_stream_id(STANDARD_REPORT),
+            "stream_alias": _expected_tap_stream_id(STANDARD_REPORT),
+            "metadata": {},
+        }
+        written = []
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema"), \
+             patch("singer.write_record",
+                   side_effect=lambda s, r, **kw: written.append(r)), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+        mock_sleep.assert_called_once()
+        self.assertGreaterEqual(len(written), 1)
+
+    @patch("time.sleep", return_value=None)
+    def test_processing_status_continues_polling(self, mock_sleep):
+        """PROCESSING status keeps polling without sleeping (unlike QUEUED)."""
+        field_type_lookup = get_field_type_lookup()
+        csv_bytes = self._csv_for_report(STANDARD_REPORT, n_rows=1)
+
+        service = build_mock_service(
+            reports_pages=[[STANDARD_REPORT]],
+            report_details=STANDARD_REPORT,
+        )
+        statuses = iter(["PROCESSING", "PROCESSING", "REPORT_AVAILABLE"])
+        service.files.return_value.get.return_value.execute.side_effect = (
+            lambda: {"status": next(statuses), "id": "file_002"}
+        )
+
+        report_config = {
+            "report_id": STANDARD_REPORT["id"],
+            "stream_name": _expected_tap_stream_id(STANDARD_REPORT),
+            "stream_alias": _expected_tap_stream_id(STANDARD_REPORT),
+            "metadata": {},
+        }
+        written = []
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema"), \
+             patch("singer.write_record",
+                   side_effect=lambda s, r, **kw: written.append(r)), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+        # PROCESSING status does NOT trigger sleep — the loop polls immediately.
+        # sleep is only called for QUEUED status; here we just verify
+        # that the file was eventually processed after the PROCESSING poll loop.
+        mock_sleep.assert_not_called()
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_unknown_file_status_raises_exception(self):
+        """An unexpected file status (FAILED, CANCELLED, …) must raise an exception."""
+        field_type_lookup = get_field_type_lookup()
+        service = build_mock_service(
+            reports_pages=[[STANDARD_REPORT]],
+            report_details=STANDARD_REPORT,
+            file_status="FAILED",
+        )
+        report_config = {
+            "report_id": STANDARD_REPORT["id"],
+            "stream_name": _expected_tap_stream_id(STANDARD_REPORT),
+            "stream_alias": _expected_tap_stream_id(STANDARD_REPORT),
+            "metadata": {},
+        }
+        with patch("singer.write_schema"), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            with self.assertRaises(Exception):
+                sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+    # ── CSV parsing edge cases ────────────────────────────────────────────
+
+    def test_empty_csv_writes_no_records(self):
+        """A CSV with no data rows produces zero written records."""
+        field_type_lookup = get_field_type_lookup()
+        headers = get_report_headers(STANDARD_REPORT)
+        csv_bytes = build_dcm_csv(headers, rows=[])  # headers only, no data rows
+
+        service = build_mock_service(
+            reports_pages=[[STANDARD_REPORT]],
+            report_details=STANDARD_REPORT,
+        )
+        report_config = {
+            "report_id": STANDARD_REPORT["id"],
+            "stream_name": _expected_tap_stream_id(STANDARD_REPORT),
+            "stream_alias": _expected_tap_stream_id(STANDARD_REPORT),
+            "metadata": {},
+        }
+        written = []
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema"), \
+             patch("singer.write_record",
+                   side_effect=lambda s, r, **kw: written.append(r)), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_report(service, field_type_lookup, self.MOCK_PROFILE_ID, report_config)
+
+        self.assertEqual(len(written), 0)
+
+    def test_grand_total_row_not_written_as_record(self):
+        """The Grand Total CSV footer row must never be written as a Singer record."""
+        written = self._run_sync_for_report(STANDARD_REPORT, n_rows=2)
+        for rec in written:
+            values = [str(v) for v in rec.values() if v is not None]
+            for val in values:
+                self.assertFalse(val.startswith("Grand Total:"),
+                                 msg="Grand Total appeared in a written record")
+
+    def test_correct_record_count_for_multiple_rows(self):
+        """sync_report must write exactly N records for N CSV data rows."""
+        for n in (1, 3, 5):
+            with self.subTest(n_rows=n):
+                written = self._run_sync_for_report(STANDARD_REPORT, n_rows=n)
+                self.assertEqual(len(written), n)
+
+
+# ---------------------------------------------------------------------------
+# sync_reports() orchestration tests
+# ---------------------------------------------------------------------------
+
+class TestDcmSyncReports(DcmBaseTest, unittest.TestCase):
+    """Test the sync_reports() orchestration layer with mocked sub-calls."""
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_selected_streams_are_synced(self, mock_ws, mock_lookup, mock_sr):
+        """sync_reports calls sync_report once for each selected stream."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog([STANDARD_REPORT, FLOODLIGHT_REPORT], selected=True)
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        self.assertEqual(mock_sr.call_count, 2)
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_unselected_streams_are_skipped(self, mock_ws, mock_lookup, mock_sr):
+        """Streams with selected=False must not be passed to sync_report."""
+        mock_lookup.return_value = {}
+        catalog = Catalog([
+            _make_catalog_entry(STANDARD_REPORT, selected=True),
+            _make_catalog_entry(FLOODLIGHT_REPORT, selected=False),
+        ])
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        synced_ids = [c[0][3]["report_id"] for c in mock_sr.call_args_list]
+        self.assertIn(STANDARD_REPORT["id"], synced_ids)
+        self.assertNotIn(FLOODLIGHT_REPORT["id"], synced_ids)
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_streams_synced_in_ascending_report_id_order(self, mock_ws, mock_lookup, mock_sr):
+        """sync_reports must call sync_report in ascending report-id order."""
+        mock_lookup.return_value = {}
+        # Pass reports in reverse order — expect sorted output
+        catalog = _make_catalog(
+            [FLOODLIGHT_REPORT, STANDARD_REPORT],  # 1002, 1001 → sort to 1001, 1002
+            selected=True,
+        )
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        call_order = [c[0][3]["report_id"] for c in mock_sr.call_args_list]
+        self.assertEqual(call_order, sorted(call_order))
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_state_cleared_after_full_sync(self, mock_ws, mock_lookup, mock_sr):
+        """After sync completes, state.current_report and state.reports must be None."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog([STANDARD_REPORT], selected=True)
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        self.assertIsNone(self.state.get("current_report"))
+        self.assertIsNone(self.state.get("reports"))
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_state_reset_when_report_list_changes(self, mock_ws, mock_lookup, mock_sr):
+        """If the report list in state differs from current, current_report resets."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog([STANDARD_REPORT], selected=True)
+        state = {"reports": [{"report_id": 9999}], "current_report": 9999}
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, state)
+        # current_report was reset to None before syncing
+        mock_sr.assert_called()
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_no_selected_streams_never_calls_sync_report(self, mock_ws, mock_lookup, mock_sr):
+        """With no selected streams sync_report must never be called."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog(
+            [STANDARD_REPORT, FLOODLIGHT_REPORT], selected=False
+        )
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        mock_sr.assert_not_called()
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_current_report_checkpoint_skips_earlier_reports(
+        self, mock_ws, mock_lookup, mock_sr
+    ):
+        """When current_report is set, reports with smaller IDs must be skipped."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog(
+            [STANDARD_REPORT, FLOODLIGHT_REPORT, CROSS_DIMENSION_REACH_REPORT],
+            selected=True,
+        )
+
+        # Build state['reports'] exactly as sync_reports() would: use the
+        # singer metadata map from each catalog entry so the equality check passes.
+        expected_reports = sorted(
+            [
+                {
+                    "report_id": singer_metadata.to_map(entry.metadata)[()][
+                        "tap-doubleclick-campaign-manager.report-id"
+                    ],
+                    "stream_name": entry.tap_stream_id,
+                    "stream_alias": entry.stream_alias,
+                    "metadata": singer_metadata.to_map(entry.metadata),
+                }
+                for entry in catalog.streams
+            ],
+            key=lambda x: x["report_id"],
+        )
+        state = {
+            "current_report": FLOODLIGHT_REPORT["id"],
+            "reports": expected_reports,
+        }
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, state)
+        synced_ids = [c[0][3]["report_id"] for c in mock_sr.call_args_list]
+        self.assertNotIn(STANDARD_REPORT["id"], synced_ids)
+        self.assertIn(FLOODLIGHT_REPORT["id"], synced_ids)
+        self.assertIn(CROSS_DIMENSION_REACH_REPORT["id"], synced_ids)
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
+    def test_all_five_report_types_synced(self, mock_ws, mock_lookup, mock_sr):
+        """sync_reports must invoke sync_report for all five DCM report types."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog(self.MOCK_REPORTS, selected=True)
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+        self.assertEqual(mock_sr.call_count, 5)
+
+    # ── Full pipeline: discover → sync ───────────────────────────────────
+
+    def test_end_to_end_discover_then_sync_writes_records(self):
+        """discover_streams() + sync_reports() end-to-end with fully mocked service."""
+        from tap_doubleclick_campaign_manager.discover import discover_streams
+
+        report = STANDARD_REPORT
+        csv_bytes = self._csv_for_report(report, n_rows=2)
+
+        service = build_mock_service(
+            reports_pages=[[report]],
+            report_details=report,
+            file_status="REPORT_AVAILABLE",
+        )
+
+        # 1. Discover
+        catalog_dict = discover_streams(service, self.MOCK_CONFIG)
+        catalog = Catalog.from_dict(catalog_dict)
+
+        # Select the stream
+        for entry in catalog.streams:
+            mdata_map = singer_metadata.to_map(entry.metadata)
+            mdata_map[()]["selected"] = True
+            entry.metadata = singer_metadata.to_list(mdata_map)
+
+        # 2. Sync
+        written = []
+        with patch("tap_doubleclick_campaign_manager.sync_reports.http.MediaIoBaseDownload",
+                   make_mock_downloader_class(csv_bytes)), \
+             patch("singer.write_schema"), \
+             patch("singer.write_state"), \
+             patch("singer.write_record",
+                   side_effect=lambda s, r, **kw: written.append(r)), \
+             patch("singer.metrics.record_counter") as mc, \
+             patch("singer.metrics.job_timer") as mt:
+
+            mc.return_value.__enter__ = lambda s: s
+            mc.return_value.__exit__ = MagicMock(return_value=False)
+            mt.return_value.__enter__ = lambda s: s
+            mt.return_value.__exit__ = MagicMock(return_value=False)
+
+            sync_reports(service, self.MOCK_CONFIG, catalog, self.state)
+
+        self.assertEqual(len(written), 2)
+        for rec in written:
+            self.assertIn(SINGER_REPORT_FIELD, rec)
+            self.assertIn(REPORT_ID_FIELD, rec)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -89,7 +89,7 @@ def _make_catalog(reports: list[dict], selected: bool = True) -> Catalog:
 # sync_report() tests
 # ---------------------------------------------------------------------------
 
-class TestDcmSyncReport(DcmBaseTest, unittest.TestCase):
+class DcmSyncReportTest(DcmBaseTest, unittest.TestCase):
     """Test the sync_report() function in isolation with mocked service."""
 
     # ── Records are written ───────────────────────────────────────────────
@@ -323,7 +323,7 @@ class TestDcmSyncReport(DcmBaseTest, unittest.TestCase):
 # sync_reports() orchestration tests
 # ---------------------------------------------------------------------------
 
-class TestDcmSyncReports(DcmBaseTest, unittest.TestCase):
+class DcmSyncReportsTest(DcmBaseTest, unittest.TestCase):
     """Test the sync_reports() orchestration layer with mocked sub-calls."""
 
     @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -498,6 +498,3 @@ class DcmSyncReportsTest(DcmBaseTest, unittest.TestCase):
             self.assertIn(SINGER_REPORT_FIELD, rec)
             self.assertIn(REPORT_ID_FIELD, rec)
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -380,6 +380,20 @@ class DcmSyncReportsTest(DcmBaseTest, unittest.TestCase):
     @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
     @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
     @patch("singer.write_state")
+    def test_full_table_sync_does_not_create_bookmarks_or_currently_syncing(
+        self, mock_ws, mock_lookup, mock_sr
+    ):
+        """FULL_TABLE DCM streams must not populate Singer bookmarks/currently_syncing."""
+        mock_lookup.return_value = {}
+        catalog = _make_catalog([STANDARD_REPORT, FLOODLIGHT_REPORT], selected=True)
+        sync_reports(MagicMock(), self.MOCK_CONFIG, catalog, self.state)
+
+        self.assertIsNone(self.state.get("bookmarks"))
+        self.assertIsNone(self.state.get("currently_syncing"))
+
+    @patch("tap_doubleclick_campaign_manager.sync_reports.sync_report")
+    @patch("tap_doubleclick_campaign_manager.sync_reports.get_field_type_lookup")
+    @patch("singer.write_state")
     def test_state_reset_when_report_list_changes(self, mock_ws, mock_lookup, mock_sr):
         """If the report list in state differs from current, current_report resets."""
         mock_lookup.return_value = {}

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -36,7 +36,7 @@ class TestDiscoverFunctions(unittest.TestCase):
         mock_reports_list = MagicMock()
         mock_reports_list.list.return_value.execute.return_value.get.return_value = mock_reports
         mock_service.reports.return_value = mock_reports_list
-        mock_client.make_request.return_value = mock_reports
+        mock_client.make_request.return_value = {'items': mock_reports}
         
         # Mock field type lookup
         mock_get_field_type_lookup.return_value = {
@@ -132,7 +132,7 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
             {'id': 100, 'name': 'Alpha Report', 'type': 'STANDARD',
              'criteria': {'dimensions': [], 'metricNames': []}},
         ]
-        mock_client.make_request.return_value = mock_reports
+        mock_client.make_request.return_value = {'items': mock_reports}
         mock_get_field_type_lookup.return_value = {}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})
@@ -146,7 +146,7 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
         """discover_streams with no reports should return a catalog with no streams."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.make_request.return_value = []
+        mock_client.make_request.return_value = {'items': []}
         mock_get_field_type_lookup.return_value = {}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})
@@ -158,10 +158,10 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
         """tap_stream_id should be '<sanitized_name>_<report_id>'."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.make_request.return_value = [
+        mock_client.make_request.return_value = {'items': [
             {'id': 42, 'name': 'My Report', 'type': 'STANDARD',
              'criteria': {'dimensions': [], 'metricNames': []}}
-        ]
+        ]}
         mock_get_field_type_lookup.return_value = {}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})
@@ -173,10 +173,10 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
         """All field-level metadata entries should have inclusion=automatic."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.make_request.return_value = [
+        mock_client.make_request.return_value = {'items': [
             {'id': 1, 'name': 'Test', 'type': 'STANDARD',
              'criteria': {'dimensions': ['date'], 'metricNames': ['impressions']}}
-        ]
+        ]}
         mock_get_field_type_lookup.return_value = {'date': 'string', 'impressions': 'long'}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})
@@ -192,10 +192,10 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
         """stream and stream_alias should both equal the sanitized report name."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.make_request.return_value = [
+        mock_client.make_request.return_value = {'items': [
             {'id': 7, 'name': 'My Stream', 'type': 'STANDARD',
              'criteria': {'dimensions': [], 'metricNames': []}}
-        ]
+        ]}
         mock_get_field_type_lookup.return_value = {}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})
@@ -208,10 +208,10 @@ class TestDiscoverStreamsExtended(unittest.TestCase):
         """key_properties should be an empty list."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.make_request.return_value = [
+        mock_client.make_request.return_value = {'items': [
             {'id': 99, 'name': 'Test Report', 'type': 'STANDARD',
              'criteria': {'dimensions': [], 'metricNames': []}}
-        ]
+        ]}
         mock_get_field_type_lookup.return_value = {}
 
         result = discover_streams(MagicMock(), {'profile_id': '99'})


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30604
 * Fix silent data truncation in `discover_streams()` — `reports.list` is a paginated API (max 10 results per page) and the previous implementation only fetched the first page, causing reports beyond page 1 to be silently omitted from the catalog. Added `nextPageToken` loop to collect all pages. 
  * Add mock integration tests for all five DCM report type streams (STANDARD, FLOODLIGHT, CROSS_DIMENSION_REACH, PATH_TO_CONVERSION, REACH) 

# Manual QA steps
- [ ] Discovery: Creds unavailable
- [ ] Sync:  Creds unavailable
- [x] Unit Tests: Passes
- [x] Integration Tests: Mock Passes

# Rollback steps
 - revert this branch

